### PR TITLE
fix: enable CI for release-please PRs and use PAT for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [release-please--branches--main]
 
 jobs:
   lint:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Release Please
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- Add push trigger for release-please branch to run CI on release PRs
- Use RELEASE_TOKEN PAT instead of GITHUB_TOKEN to allow release events to trigger downstream publish workflow

**Note:** Requires `RELEASE_TOKEN` secret to be configured before merging.