### PR TITLE
ci: remove duplicate trigger for release-please branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [release-please--branches--main]
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- Remove push trigger for release-please branch to prevent duplicate CI runs
- PAT token now allows pull_request events to trigger CI for release-please PRs