### PR TITLE
feat: add PipelineRunner trait with lifecycle hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+# Pre-commit configuration for spark-pipeline-framework
+#
+# Installation:
+#   pip install pre-commit
+#   pre-commit install
+#
+# Manual run:
+#   pre-commit run --all-files
+#
+repos:
+  - repo: local
+    hooks:
+      - id: scalafmt
+        name: scalafmt
+        entry: sbt --error scalafmtCheckAll
+        language: system
+        pass_filenames: false
+        types: [scala]
+        stages: [pre-commit]
+
+      - id: scalastyle
+        name: scalastyle
+        entry: sbt --error scalastyle
+        language: system
+        pass_filenames: false
+        types: [scala]
+        stages: [pre-commit]

--- a/build.sbt
+++ b/build.sbt
@@ -243,16 +243,18 @@ lazy val runner = (projectMatrix in file("runner"))
   )
 
 // ============================================================================
-// Example Module - Shows how to use the framework (depends on runtime only)
+// Example Module - Shows how to use the framework
 // ============================================================================
 lazy val exampleModulePrefix = "spark-pipeline-example"
 
 lazy val example = (projectMatrix in file("example"))
-  .dependsOn(runtime)
+  .dependsOn(runtime, runner)
   .settings(
     name := "spark-pipeline-example",
     commonSettings,
-    publish / skip := true
+    publish / skip := true,
+    // Exclude DemoPipeline from coverage - it's a runnable demo with main()
+    coverageExcludedFiles := ".*DemoPipeline.*"
   )
   .customRow(
     scalaVersions = Seq(scala212),

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/PipelineHooks.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/PipelineHooks.scala
@@ -1,0 +1,137 @@
+package io.github.dwsmith1983.spark.pipeline.config
+
+/**
+ * Lifecycle hooks for pipeline execution.
+ *
+ * Implement this trait to add custom behavior at various points during
+ * pipeline execution, such as logging, metrics collection, alerting,
+ * or custom error handling.
+ *
+ * All methods have default no-op implementations, so you only need to
+ * override the hooks you're interested in.
+ *
+ * == Example ==
+ *
+ * {{{
+ * val metricsHooks = new PipelineHooks {
+ *   override def beforePipeline(config: PipelineConfig): Unit =
+ *     println(s"Starting pipeline: $${config.pipelineName}")
+ *
+ *   override def afterComponent(
+ *     config: ComponentConfig,
+ *     index: Int,
+ *     total: Int,
+ *     durationMs: Long
+ *   ): Unit =
+ *     metrics.recordComponentDuration(config.instanceName, durationMs)
+ *
+ *   override def afterPipeline(config: PipelineConfig, result: PipelineResult): Unit =
+ *     result match {
+ *       case PipelineResult.Success(duration, _) =>
+ *         println(s"Pipeline completed in $${duration}ms")
+ *       case PipelineResult.Failure(error, _, _) =>
+ *         alerting.sendAlert(s"Pipeline failed: $${error.getMessage}")
+ *     }
+ * }
+ *
+ * SimplePipelineRunner.run(config, metricsHooks)
+ * }}}
+ */
+trait PipelineHooks {
+
+  /**
+   * Called before pipeline execution begins.
+   *
+   * @param config The pipeline configuration
+   */
+  def beforePipeline(config: PipelineConfig): Unit = {
+    val _ = config // suppress unused warning - meant to be overridden
+  }
+
+  /**
+   * Called after pipeline execution completes (success or failure).
+   *
+   * @param config The pipeline configuration
+   * @param result The pipeline execution result
+   */
+  def afterPipeline(config: PipelineConfig, result: PipelineResult): Unit = {
+    val _ = (config, result) // suppress unused warning - meant to be overridden
+  }
+
+  /**
+   * Called before each component is instantiated and run.
+   *
+   * @param config The component configuration
+   * @param index Zero-based index of the component in the pipeline
+   * @param total Total number of components in the pipeline
+   */
+  def beforeComponent(config: ComponentConfig, index: Int, total: Int): Unit = {
+    val _ = (config, index, total) // suppress unused warning - meant to be overridden
+  }
+
+  /**
+   * Called after each component completes successfully.
+   *
+   * @param config The component configuration
+   * @param index Zero-based index of the component in the pipeline
+   * @param total Total number of components in the pipeline
+   * @param durationMs Execution time in milliseconds
+   */
+  def afterComponent(
+    config: ComponentConfig,
+    index: Int,
+    total: Int,
+    durationMs: Long
+  ): Unit = {
+    val _ = (config, index, total, durationMs) // suppress unused warning - meant to be overridden
+  }
+
+  /**
+   * Called when a component fails during execution.
+   *
+   * This is called before the exception is propagated. The pipeline will
+   * stop execution after this hook returns.
+   *
+   * @param config The component configuration that failed
+   * @param index Zero-based index of the failed component
+   * @param error The exception that was thrown
+   */
+  def onComponentFailure(config: ComponentConfig, index: Int, error: Throwable): Unit = {
+    val _ = (config, index, error) // suppress unused warning - meant to be overridden
+  }
+}
+
+object PipelineHooks {
+
+  /** A no-op implementation that does nothing at each hook point. */
+  val NoOp: PipelineHooks = new PipelineHooks {}
+
+  /**
+   * Combines multiple hooks into a single hook that calls each in order.
+   *
+   * @param hooks The hooks to combine
+   * @return A composite hook that delegates to all provided hooks
+   */
+  def compose(hooks: PipelineHooks*): PipelineHooks = new PipelineHooks {
+
+    override def beforePipeline(config: PipelineConfig): Unit =
+      hooks.foreach(_.beforePipeline(config))
+
+    override def afterPipeline(config: PipelineConfig, result: PipelineResult): Unit =
+      hooks.foreach(_.afterPipeline(config, result))
+
+    override def beforeComponent(config: ComponentConfig, index: Int, total: Int): Unit =
+      hooks.foreach(_.beforeComponent(config, index, total))
+
+    override def afterComponent(
+      config: ComponentConfig,
+      index: Int,
+      total: Int,
+      durationMs: Long
+    ): Unit =
+      hooks.foreach(_.afterComponent(config, index, total, durationMs))
+
+    override def onComponentFailure(config: ComponentConfig, index: Int, error: Throwable): Unit =
+      hooks.foreach(_.onComponentFailure(config, index, error))
+  }
+}

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/PipelineResult.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/PipelineResult.scala
@@ -1,0 +1,43 @@
+package io.github.dwsmith1983.spark.pipeline.config
+
+/**
+ * Result of a pipeline execution.
+ *
+ * Used by [[PipelineHooks]] to communicate pipeline completion status.
+ */
+sealed trait PipelineResult {
+
+  /** Whether the pipeline completed successfully. */
+  def isSuccess: Boolean
+
+  /** Whether the pipeline failed. */
+  def isFailure: Boolean = !isSuccess
+}
+
+object PipelineResult {
+
+  /**
+   * Indicates successful pipeline completion.
+   *
+   * @param durationMs Total pipeline execution time in milliseconds
+   * @param componentsRun Number of components that were executed
+   */
+  final case class Success(durationMs: Long, componentsRun: Int) extends PipelineResult {
+    override def isSuccess: Boolean = true
+  }
+
+  /**
+   * Indicates pipeline failure.
+   *
+   * @param error The exception that caused the failure
+   * @param failedComponent The component configuration that failed, if applicable
+   * @param componentsCompleted Number of components that completed before failure
+   */
+  final case class Failure(
+    error: Throwable,
+    failedComponent: Option[ComponentConfig],
+    componentsCompleted: Int)
+    extends PipelineResult {
+    override def isSuccess: Boolean = false
+  }
+}

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/package.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/package.scala
@@ -12,6 +12,8 @@ package io.github.dwsmith1983.spark.pipeline
  * - [[config.ComponentConfig]] - Configuration model for individual components
  * - [[config.SparkConfig]] - Configuration model for Spark session settings
  * - [[config.ComponentInstantiator]] - Utility for reflection-based component instantiation
+ * - [[config.PipelineHooks]] - Lifecycle hooks for pipeline execution monitoring
+ * - [[config.PipelineResult]] - Result type for pipeline execution (Success/Failure)
  *
  * Example usage in user code:
  * {{{

--- a/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/config/PipelineHooksSpec.scala
+++ b/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/config/PipelineHooksSpec.scala
@@ -1,0 +1,195 @@
+package io.github.dwsmith1983.spark.pipeline.config
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.mutable
+
+/** Tests for PipelineHooks trait and companion object. */
+class PipelineHooksSpec extends AnyFunSpec with Matchers {
+
+  val samplePipelineConfig: PipelineConfig = PipelineConfig(
+    pipelineName = "Test Pipeline",
+    pipelineComponents = List.empty
+  )
+
+  val sampleComponentConfig: ComponentConfig = ComponentConfig(
+    instanceType = "com.example.TestComponent",
+    instanceName = "TestComponent",
+    instanceConfig = ConfigFactory.empty()
+  )
+
+  describe("PipelineHooks.NoOp") {
+
+    it("should not throw when beforePipeline is called") {
+      noException should be thrownBy {
+        PipelineHooks.NoOp.beforePipeline(samplePipelineConfig)
+      }
+    }
+
+    it("should not throw when afterPipeline is called") {
+      val result: PipelineResult = PipelineResult.Success(100L, 1)
+
+      noException should be thrownBy {
+        PipelineHooks.NoOp.afterPipeline(samplePipelineConfig, result)
+      }
+    }
+
+    it("should not throw when beforeComponent is called") {
+      noException should be thrownBy {
+        PipelineHooks.NoOp.beforeComponent(sampleComponentConfig, 0, 1)
+      }
+    }
+
+    it("should not throw when afterComponent is called") {
+      noException should be thrownBy {
+        PipelineHooks.NoOp.afterComponent(sampleComponentConfig, 0, 1, 50L)
+      }
+    }
+
+    it("should not throw when onComponentFailure is called") {
+      val error: RuntimeException = new RuntimeException("test")
+
+      noException should be thrownBy {
+        PipelineHooks.NoOp.onComponentFailure(sampleComponentConfig, 0, error)
+      }
+    }
+  }
+
+  describe("PipelineHooks.compose") {
+
+    it("should call beforePipeline on all hooks in order") {
+      val tracker1: TestHooksTracker = new TestHooksTracker("H1")
+      val tracker2: TestHooksTracker = new TestHooksTracker("H2")
+
+      val composed: PipelineHooks = PipelineHooks.compose(tracker1, tracker2)
+      composed.beforePipeline(samplePipelineConfig)
+
+      tracker1.events shouldBe List("H1:beforePipeline")
+      tracker2.events shouldBe List("H2:beforePipeline")
+    }
+
+    it("should call afterPipeline on all hooks") {
+      val tracker1: TestHooksTracker = new TestHooksTracker("H1")
+      val tracker2: TestHooksTracker = new TestHooksTracker("H2")
+      val result: PipelineResult     = PipelineResult.Success(100L, 1)
+
+      val composed: PipelineHooks = PipelineHooks.compose(tracker1, tracker2)
+      composed.afterPipeline(samplePipelineConfig, result)
+
+      tracker1.events shouldBe List("H1:afterPipeline")
+      tracker2.events shouldBe List("H2:afterPipeline")
+    }
+
+    it("should call beforeComponent on all hooks") {
+      val tracker1: TestHooksTracker = new TestHooksTracker("H1")
+      val tracker2: TestHooksTracker = new TestHooksTracker("H2")
+
+      val composed: PipelineHooks = PipelineHooks.compose(tracker1, tracker2)
+      composed.beforeComponent(sampleComponentConfig, 0, 3)
+
+      tracker1.events shouldBe List("H1:beforeComponent")
+      tracker2.events shouldBe List("H2:beforeComponent")
+    }
+
+    it("should call afterComponent on all hooks") {
+      val tracker1: TestHooksTracker = new TestHooksTracker("H1")
+      val tracker2: TestHooksTracker = new TestHooksTracker("H2")
+
+      val composed: PipelineHooks = PipelineHooks.compose(tracker1, tracker2)
+      composed.afterComponent(sampleComponentConfig, 1, 3, 200L)
+
+      tracker1.events shouldBe List("H1:afterComponent")
+      tracker2.events shouldBe List("H2:afterComponent")
+    }
+
+    it("should call onComponentFailure on all hooks") {
+      val tracker1: TestHooksTracker = new TestHooksTracker("H1")
+      val tracker2: TestHooksTracker = new TestHooksTracker("H2")
+      val error: RuntimeException    = new RuntimeException("test error")
+
+      val composed: PipelineHooks = PipelineHooks.compose(tracker1, tracker2)
+      composed.onComponentFailure(sampleComponentConfig, 0, error)
+
+      tracker1.events shouldBe List("H1:onComponentFailure")
+      tracker2.events shouldBe List("H2:onComponentFailure")
+    }
+
+    it("should handle empty hooks list") {
+      val composed: PipelineHooks = PipelineHooks.compose()
+
+      noException should be thrownBy {
+        composed.beforePipeline(samplePipelineConfig)
+        composed.afterPipeline(samplePipelineConfig, PipelineResult.Success(100L, 0))
+      }
+    }
+
+    it("should handle single hook") {
+      val tracker: TestHooksTracker = new TestHooksTracker("Single")
+
+      val composed: PipelineHooks = PipelineHooks.compose(tracker)
+      composed.beforePipeline(samplePipelineConfig)
+
+      tracker.events shouldBe List("Single:beforePipeline")
+    }
+  }
+
+  describe("default implementations") {
+
+    it("should allow extending with only specific overrides") {
+      var beforeCalled: Boolean = false
+
+      val customHooks: PipelineHooks = new PipelineHooks {
+        override def beforePipeline(config: PipelineConfig): Unit =
+          beforeCalled = true
+      }
+
+      customHooks.beforePipeline(samplePipelineConfig)
+      beforeCalled shouldBe true
+
+      // Other methods should not throw
+      noException should be thrownBy {
+        customHooks.afterPipeline(samplePipelineConfig, PipelineResult.Success(100L, 0))
+        customHooks.beforeComponent(sampleComponentConfig, 0, 1)
+        customHooks.afterComponent(sampleComponentConfig, 0, 1, 50L)
+        customHooks.onComponentFailure(sampleComponentConfig, 0, new RuntimeException("test"))
+      }
+    }
+  }
+}
+
+/** Test helper to track hook invocations. */
+class TestHooksTracker(name: String) extends PipelineHooks {
+  val events: mutable.ListBuffer[String] = mutable.ListBuffer.empty
+
+  override def beforePipeline(config: PipelineConfig): Unit = {
+    val _ = config
+    events += s"$name:beforePipeline"
+  }
+
+  override def afterPipeline(config: PipelineConfig, result: PipelineResult): Unit = {
+    val _ = (config, result)
+    events += s"$name:afterPipeline"
+  }
+
+  override def beforeComponent(config: ComponentConfig, index: Int, total: Int): Unit = {
+    val _ = (config, index, total)
+    events += s"$name:beforeComponent"
+  }
+
+  override def afterComponent(
+    config: ComponentConfig,
+    index: Int,
+    total: Int,
+    durationMs: Long
+  ): Unit = {
+    val _ = (config, index, total, durationMs)
+    events += s"$name:afterComponent"
+  }
+
+  override def onComponentFailure(config: ComponentConfig, index: Int, error: Throwable): Unit = {
+    val _ = (config, index, error)
+    events += s"$name:onComponentFailure"
+  }
+}

--- a/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/config/PipelineResultSpec.scala
+++ b/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/config/PipelineResultSpec.scala
@@ -1,0 +1,69 @@
+package io.github.dwsmith1983.spark.pipeline.config
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+/** Tests for PipelineResult sealed trait and its case classes. */
+class PipelineResultSpec extends AnyFunSpec with Matchers {
+
+  describe("PipelineResult.Success") {
+
+    it("should report isSuccess as true") {
+      val result: PipelineResult = PipelineResult.Success(durationMs = 1000L, componentsRun = 3)
+
+      result.isSuccess shouldBe true
+    }
+
+    it("should report isFailure as false") {
+      val result: PipelineResult = PipelineResult.Success(durationMs = 500L, componentsRun = 1)
+
+      result.isFailure shouldBe false
+    }
+
+    it("should store duration and components count") {
+      val result: PipelineResult.Success = PipelineResult.Success(durationMs = 2500L, componentsRun = 5)
+
+      result.durationMs shouldBe 2500L
+      result.componentsRun shouldBe 5
+    }
+  }
+
+  describe("PipelineResult.Failure") {
+
+    it("should report isSuccess as false") {
+      val error: RuntimeException = new RuntimeException("test error")
+      val result: PipelineResult  = PipelineResult.Failure(error, failedComponent = None, componentsCompleted = 0)
+
+      result.isSuccess shouldBe false
+    }
+
+    it("should report isFailure as true") {
+      val error: RuntimeException = new RuntimeException("test error")
+      val result: PipelineResult  = PipelineResult.Failure(error, failedComponent = None, componentsCompleted = 0)
+
+      result.isFailure shouldBe true
+    }
+
+    it("should store error and failed component") {
+      val error: RuntimeException = new RuntimeException("component failed")
+      val componentConfig: ComponentConfig = ComponentConfig(
+        instanceType = "com.example.MyComponent",
+        instanceName = "FailedComponent",
+        instanceConfig = com.typesafe.config.ConfigFactory.empty()
+      )
+      val result: PipelineResult.Failure =
+        PipelineResult.Failure(error, failedComponent = Some(componentConfig), componentsCompleted = 2)
+
+      result.error shouldBe error
+      result.failedComponent shouldBe Some(componentConfig)
+      result.componentsCompleted shouldBe 2
+    }
+
+    it("should allow None for failedComponent") {
+      val error: RuntimeException = new RuntimeException("config error")
+      val result: PipelineResult.Failure = PipelineResult.Failure(error, failedComponent = None, componentsCompleted = 0)
+
+      result.failedComponent shouldBe None
+    }
+  }
+}

--- a/example/src/main/scala/io/github/dwsmith1983/pipelines/DemoPipeline.scala
+++ b/example/src/main/scala/io/github/dwsmith1983/pipelines/DemoPipeline.scala
@@ -1,0 +1,169 @@
+package io.github.dwsmith1983.pipelines
+
+import io.github.dwsmith1983.spark.pipeline.config._
+import io.github.dwsmith1983.spark.pipeline.runner.SimplePipelineRunner
+import com.typesafe.config.{Config, ConfigFactory}
+
+import java.nio.file.{Files, Path}
+
+/**
+ * End-to-end demonstration of spark-pipeline-framework.
+ *
+ * This runnable example shows:
+ * - Programmatic config creation (can also use HOCON files)
+ * - Multi-component pipeline execution
+ * - MetricsHooks for execution monitoring
+ * - PipelineResult handling for success/failure
+ *
+ * == Running ==
+ *
+ * {{{
+ * # From sbt
+ * sbt "examplespark3/runMain io.github.dwsmith1983.pipelines.DemoPipeline"
+ *
+ * # Or with spark-submit
+ * spark-submit \
+ *   --class io.github.dwsmith1983.pipelines.DemoPipeline \
+ *   --master local[*] \
+ *   spark-pipeline-example-spark3_2.13.jar
+ * }}}
+ */
+object DemoPipeline {
+
+  def main(args: Array[String]): Unit = {
+    println("=" * 70)
+    println("  SPARK PIPELINE FRAMEWORK - END-TO-END DEMO")
+    println("=" * 70)
+    println()
+
+    // Create temp directories for demo data
+    val tempDir: Path    = Files.createTempDirectory("pipeline-demo")
+    val inputFile: Path  = tempDir.resolve("sample-text.txt")
+    val outputDir1: Path = tempDir.resolve("wordcount-output")
+    val outputDir2: Path = tempDir.resolve("filtered-output")
+
+    try {
+      // Create sample input data
+      println("[SETUP] Creating sample input data...")
+      val sampleText: String =
+        """Apache Spark is a unified analytics engine for large-scale data processing.
+          |Spark provides high-level APIs in Java, Scala, Python, and R.
+          |Spark also supports a rich set of higher-level tools including Spark SQL.
+          |The pipeline framework makes it easy to build configuration-driven Spark applications.
+          |Configuration-driven pipelines reduce boilerplate and improve maintainability.
+          |Hooks provide visibility into pipeline execution with minimal code changes.
+          |""".stripMargin
+      val _: Path = Files.writeString(inputFile, sampleText)
+      println(s"[SETUP] Input file: $inputFile")
+      println()
+
+      // Build pipeline configuration programmatically
+      // (In production, this would typically come from a HOCON file)
+      val config: Config = ConfigFactory.parseString(s"""
+        spark {
+          master = "local[*]"
+          app-name = "Pipeline Demo"
+          config {
+            "spark.ui.enabled" = "false"
+            "spark.sql.shuffle.partitions" = "4"
+          }
+        }
+
+        pipeline {
+          pipeline-name = "Word Analysis Pipeline"
+          pipeline-components = [
+            {
+              instance-type = "io.github.dwsmith1983.pipelines.WordCount"
+              instance-name = "WordCount(all words)"
+              instance-config {
+                input-path = "${inputFile.toString.replace("\\", "/")}"
+                output-path = "${outputDir1.toString.replace("\\", "/")}"
+                min-count = 1
+                write-format = "parquet"
+              }
+            },
+            {
+              instance-type = "io.github.dwsmith1983.pipelines.WordCount"
+              instance-name = "WordCount(frequent words only)"
+              instance-config {
+                input-path = "${inputFile.toString.replace("\\", "/")}"
+                output-path = "${outputDir2.toString.replace("\\", "/")}"
+                min-count = 2
+                write-format = "json"
+              }
+            }
+          ]
+        }
+      """)
+
+      // Create metrics hooks to monitor execution
+      val metrics = new MetricsHooks()
+
+      // Custom logging hooks to show execution flow
+      val loggingHooks = new PipelineHooks {
+        override def beforePipeline(config: PipelineConfig): Unit =
+          println(s"\n[PIPELINE START] ${config.pipelineName} (${config.pipelineComponents.size} components)")
+
+        override def beforeComponent(config: ComponentConfig, index: Int, total: Int): Unit =
+          println(s"  [${index + 1}/$total] Starting: ${config.instanceName}")
+
+        override def afterComponent(
+          config: ComponentConfig,
+          index: Int,
+          total: Int,
+          durationMs: Long
+        ): Unit =
+          println(s"  [${index + 1}/$total] Completed: ${config.instanceName} (${durationMs}ms)")
+
+        override def afterPipeline(config: PipelineConfig, result: PipelineResult): Unit = {
+          val _ = config
+          result match {
+            case PipelineResult.Success(duration, count) =>
+              println(s"\n[PIPELINE COMPLETE] $count components executed in ${duration}ms")
+            case PipelineResult.Failure(error, failed, completed) =>
+              println(s"\n[PIPELINE FAILED] After $completed components")
+              failed.foreach(c => println(s"  Failed component: ${c.instanceName}"))
+              println(s"  Error: ${error.getMessage}")
+          }
+        }
+
+        override def onComponentFailure(config: ComponentConfig, index: Int, error: Throwable): Unit = {
+          val _ = error
+          println(s"  [${index + 1}] FAILED: ${config.instanceName}")
+        }
+      }
+
+      // Compose multiple hooks together
+      val combinedHooks: PipelineHooks = PipelineHooks.compose(loggingHooks, metrics)
+
+      // Run the pipeline
+      println("[RUNNING] Executing pipeline with composed hooks...")
+      SimplePipelineRunner.run(config, combinedHooks)
+
+      // Display metrics report
+      println()
+      println("=" * 70)
+      println("  METRICS REPORT")
+      println("=" * 70)
+      println(metrics.generateReport())
+
+      // Show output locations
+      println("=" * 70)
+      println("  OUTPUT LOCATIONS")
+      println("=" * 70)
+      println(s"  All words:      $outputDir1")
+      println(s"  Frequent words: $outputDir2")
+      println()
+
+    } finally {
+      // Cleanup
+      println("[CLEANUP] Removing temporary files...")
+      Files.walk(tempDir)
+        .sorted(java.util.Comparator.reverseOrder())
+        .forEach { (p: Path) =>
+          val _: Boolean = Files.deleteIfExists(p)
+        }
+      println("[DONE]")
+    }
+  }
+}

--- a/example/src/main/scala/io/github/dwsmith1983/pipelines/MetricsHooks.scala
+++ b/example/src/main/scala/io/github/dwsmith1983/pipelines/MetricsHooks.scala
@@ -1,0 +1,141 @@
+package io.github.dwsmith1983.pipelines
+
+import io.github.dwsmith1983.spark.pipeline.config._
+
+import scala.collection.mutable
+
+/**
+ * Example PipelineHooks implementation for collecting execution metrics.
+ *
+ * This demonstrates a practical use case for lifecycle hooks:
+ * - Tracking component execution times
+ * - Recording success/failure counts
+ * - Generating pipeline execution reports
+ *
+ * == Usage ==
+ *
+ * {{{
+ * val metrics = new MetricsHooks()
+ * SimplePipelineRunner.run(config, metrics)
+ *
+ * // After execution, access the collected metrics
+ * println(s"Total duration: $${metrics.totalDurationMs}ms")
+ * println(s"Components run: $${metrics.componentCount}")
+ * metrics.componentDurations.foreach { case (name, duration) =>
+ *   println(s"  $$name: $${duration}ms")
+ * }
+ * }}}
+ *
+ * == Composing with Other Hooks ==
+ *
+ * {{{
+ * val composed = PipelineHooks.compose(
+ *   new MetricsHooks(),
+ *   new AlertingHooks(slackWebhook)
+ * )
+ * SimplePipelineRunner.run(config, composed)
+ * }}}
+ */
+class MetricsHooks extends PipelineHooks {
+
+  // Collected metrics
+  private var _pipelineName: String                                    = _
+  private var _pipelineStartTime: Long                                 = 0L
+  private var _totalDurationMs: Long                                   = 0L
+  private var _componentCount: Int                                     = 0
+  private var _successCount: Int                                       = 0
+  private var _failureCount: Int                                       = 0
+  private val _componentDurations: mutable.LinkedHashMap[String, Long] = mutable.LinkedHashMap.empty
+  private var _failedComponent: Option[String]                         = None
+  private var _failureError: Option[Throwable]                         = None
+
+  // Accessors for collected metrics
+  def pipelineName: String                  = _pipelineName
+  def totalDurationMs: Long                 = _totalDurationMs
+  def componentCount: Int                   = _componentCount
+  def successCount: Int                     = _successCount
+  def failureCount: Int                     = _failureCount
+  def componentDurations: Map[String, Long] = _componentDurations.toMap
+  def failedComponent: Option[String]       = _failedComponent
+  def failureError: Option[Throwable]       = _failureError
+  def wasSuccessful: Boolean                = _failureCount == 0
+
+  override def beforePipeline(config: PipelineConfig): Unit = {
+    _pipelineName = config.pipelineName
+    _pipelineStartTime = System.currentTimeMillis()
+    _componentCount = config.pipelineComponents.size
+  }
+
+  override def afterComponent(
+    config: ComponentConfig,
+    index: Int,
+    total: Int,
+    durationMs: Long
+  ): Unit = {
+    _componentDurations(config.instanceName) = durationMs
+    _successCount += 1
+  }
+
+  override def onComponentFailure(config: ComponentConfig, index: Int, error: Throwable): Unit = {
+    _failedComponent = Some(config.instanceName)
+    _failureError = Some(error)
+    _failureCount += 1
+  }
+
+  override def afterPipeline(config: PipelineConfig, result: PipelineResult): Unit = {
+    val _ = config // suppress unused warning
+    _totalDurationMs = result match {
+      case PipelineResult.Success(duration, _) => duration
+      case PipelineResult.Failure(_, _, _)     => System.currentTimeMillis() - _pipelineStartTime
+    }
+  }
+
+  /**
+   * Generates a formatted report of the pipeline execution.
+   *
+   * @return Multi-line string with execution summary
+   */
+  def generateReport(): String = {
+    val sb = new StringBuilder()
+    sb.append(s"Pipeline: ${_pipelineName}\n")
+    sb.append(s"Status: ${if (wasSuccessful) "SUCCESS" else "FAILED"}\n")
+    sb.append(s"Total Duration: ${_totalDurationMs}ms\n")
+    sb.append(s"Components: ${_successCount}/${_componentCount} completed\n")
+
+    if (_componentDurations.nonEmpty) {
+      sb.append("\nComponent Timings:\n")
+      _componentDurations.foreach {
+        case (name, duration) =>
+          val pct = if (_totalDurationMs > 0) duration * 100.0 / _totalDurationMs else 0.0
+          sb.append(f"  $name: ${duration}ms ($pct%.1f%%)\n")
+      }
+    }
+
+    _failedComponent.foreach { name =>
+      sb.append(s"\nFailed Component: $name\n")
+      _failureError.foreach(error => sb.append(s"Error: ${error.getMessage}\n"))
+    }
+
+    sb.toString()
+  }
+
+  /** Resets all collected metrics for reuse. */
+  def reset(): Unit = {
+    _pipelineName = null
+    _pipelineStartTime = 0L
+    _totalDurationMs = 0L
+    _componentCount = 0
+    _successCount = 0
+    _failureCount = 0
+    _componentDurations.clear()
+    _failedComponent = None
+    _failureError = None
+  }
+}
+
+/** Companion object with a pre-built instance for simple usage. */
+object MetricsHooks {
+
+  /** Creates a new MetricsHooks instance. */
+  def apply(): MetricsHooks = new MetricsHooks()
+}

--- a/example/src/test/scala/io/github/dwsmith1983/pipelines/MetricsHooksSpec.scala
+++ b/example/src/test/scala/io/github/dwsmith1983/pipelines/MetricsHooksSpec.scala
@@ -1,0 +1,224 @@
+package io.github.dwsmith1983.pipelines
+
+import io.github.dwsmith1983.spark.pipeline.config._
+import io.github.dwsmith1983.spark.pipeline.runtime.SparkSessionWrapper
+import io.github.dwsmith1983.spark.pipeline.runner.SimplePipelineRunner
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.BeforeAndAfterAll
+
+import java.nio.file.{Files, Path}
+
+/**
+ * Tests for MetricsHooks example implementation.
+ *
+ * Demonstrates practical usage of PipelineHooks for metrics collection.
+ */
+class MetricsHooksSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach with BeforeAndAfterAll {
+
+  var tempDir: Path   = _
+  var inputFile: Path = _
+  var outputDir: Path = _
+
+  override def beforeEach(): Unit = {
+    SparkSessionWrapper.stop()
+
+    // Create temp directories for test data
+    tempDir = Files.createTempDirectory("metrics-hooks-test")
+    inputFile = tempDir.resolve("input.txt")
+    outputDir = tempDir.resolve("output")
+
+    // Create sample input
+    val _: Path = Files.writeString(inputFile, "hello world hello spark world world")
+  }
+
+  override def afterEach(): Unit = {
+    SparkSessionWrapper.stop()
+    // Clean up temp files
+    if (tempDir != null) {
+      Files.walk(tempDir).sorted(java.util.Comparator.reverseOrder())
+        .forEach { (p: Path) =>
+          val _: Boolean = Files.deleteIfExists(p)
+        }
+    }
+  }
+
+  override def afterAll(): Unit =
+    SparkSessionWrapper.stop()
+
+  describe("MetricsHooks") {
+
+    it("should collect metrics for successful pipeline") {
+      val config = ConfigFactory.parseString(s"""
+        spark {
+          master = "local[1]"
+          app-name = "MetricsTest"
+        }
+        pipeline {
+          pipeline-name = "Word Count Pipeline"
+          pipeline-components = [
+            {
+              instance-type = "io.github.dwsmith1983.pipelines.WordCount"
+              instance-name = "WordCount(test)"
+              instance-config {
+                input-path = "${inputFile.toString.replace("\\", "/")}"
+                output-path = "${outputDir.toString.replace("\\", "/")}"
+                min-count = 1
+              }
+            }
+          ]
+        }
+      """)
+
+      val metrics = MetricsHooks()
+
+      SimplePipelineRunner.run(config, metrics)
+
+      // Verify metrics were collected
+      metrics.pipelineName shouldBe "Word Count Pipeline"
+      metrics.wasSuccessful shouldBe true
+      metrics.componentCount shouldBe 1
+      metrics.successCount shouldBe 1
+      metrics.failureCount shouldBe 0
+      metrics.totalDurationMs should be > 0L
+      (metrics.componentDurations should contain).key("WordCount(test)")
+      metrics.failedComponent shouldBe None
+    }
+
+    it("should generate readable report") {
+      val config = ConfigFactory.parseString(s"""
+        spark {
+          master = "local[1]"
+          app-name = "ReportTest"
+        }
+        pipeline {
+          pipeline-name = "Report Test Pipeline"
+          pipeline-components = [
+            {
+              instance-type = "io.github.dwsmith1983.pipelines.WordCount"
+              instance-name = "WordCount(report)"
+              instance-config {
+                input-path = "${inputFile.toString.replace("\\", "/")}"
+                output-path = "${outputDir.toString.replace("\\", "/")}"
+              }
+            }
+          ]
+        }
+      """)
+
+      val metrics = MetricsHooks()
+      SimplePipelineRunner.run(config, metrics)
+
+      val report = metrics.generateReport()
+
+      report should include("Pipeline: Report Test Pipeline")
+      report should include("Status: SUCCESS")
+      report should include("Total Duration:")
+      report should include("Components: 1/1 completed")
+      report should include("WordCount(report):")
+    }
+
+    it("should track failure information") {
+      val config = ConfigFactory.parseString(s"""
+        spark {
+          master = "local[1]"
+        }
+        pipeline {
+          pipeline-name = "Failure Test"
+          pipeline-components = [
+            {
+              instance-type = "io.github.dwsmith1983.pipelines.WordCount"
+              instance-name = "WillFail"
+              instance-config {
+                input-path = "/nonexistent/path/that/does/not/exist"
+                output-path = "${outputDir.toString.replace("\\", "/")}"
+              }
+            }
+          ]
+        }
+      """)
+
+      val metrics = MetricsHooks()
+
+      intercept[Exception] {
+        SimplePipelineRunner.run(config, metrics)
+      }
+
+      metrics.wasSuccessful shouldBe false
+      metrics.failureCount shouldBe 1
+      metrics.failedComponent shouldBe Some("WillFail")
+      metrics.failureError shouldBe defined
+    }
+
+    it("should support reset for reuse") {
+      val metrics = MetricsHooks()
+
+      // Simulate some state
+      val config = ConfigFactory.parseString(s"""
+        spark {
+          master = "local[1]"
+        }
+        pipeline {
+          pipeline-name = "Reset Test"
+          pipeline-components = [
+            {
+              instance-type = "io.github.dwsmith1983.pipelines.WordCount"
+              instance-name = "WordCount(reset)"
+              instance-config {
+                input-path = "${inputFile.toString.replace("\\", "/")}"
+                output-path = "${outputDir.toString.replace("\\", "/")}"
+              }
+            }
+          ]
+        }
+      """)
+
+      SimplePipelineRunner.run(config, metrics)
+      metrics.successCount should be > 0
+
+      // Reset and verify clean state
+      metrics.reset()
+
+      metrics.pipelineName shouldBe null
+      metrics.totalDurationMs shouldBe 0L
+      metrics.componentCount shouldBe 0
+      metrics.successCount shouldBe 0
+      metrics.failureCount shouldBe 0
+      metrics.componentDurations shouldBe empty
+    }
+
+    it("should work with PipelineHooks.compose") {
+      val config = ConfigFactory.parseString(s"""
+        spark {
+          master = "local[1]"
+        }
+        pipeline {
+          pipeline-name = "Compose Test"
+          pipeline-components = [
+            {
+              instance-type = "io.github.dwsmith1983.pipelines.WordCount"
+              instance-name = "WordCount(compose)"
+              instance-config {
+                input-path = "${inputFile.toString.replace("\\", "/")}"
+                output-path = "${outputDir.toString.replace("\\", "/")}"
+              }
+            }
+          ]
+        }
+      """)
+
+      val metrics1 = MetricsHooks()
+      val metrics2 = MetricsHooks()
+      val composed = PipelineHooks.compose(metrics1, metrics2)
+
+      SimplePipelineRunner.run(config, composed)
+
+      // Both hooks should have collected the same metrics
+      metrics1.successCount shouldBe 1
+      metrics2.successCount shouldBe 1
+      metrics1.pipelineName shouldBe metrics2.pipelineName
+    }
+  }
+}

--- a/runner/src/main/scala/io/github/dwsmith1983/spark/pipeline/runner/PipelineRunner.scala
+++ b/runner/src/main/scala/io/github/dwsmith1983/spark/pipeline/runner/PipelineRunner.scala
@@ -1,0 +1,63 @@
+package io.github.dwsmith1983.spark.pipeline.runner
+
+import com.typesafe.config.Config
+import io.github.dwsmith1983.spark.pipeline.config.PipelineHooks
+
+/**
+ * Trait defining the interface for pipeline execution.
+ *
+ * Implementations of this trait are responsible for:
+ * - Loading and parsing pipeline configuration
+ * - Configuring the SparkSession
+ * - Instantiating and executing pipeline components
+ * - Invoking lifecycle hooks at appropriate points
+ *
+ * == Standard Implementation ==
+ *
+ * The framework provides [[SimplePipelineRunner]] as the standard implementation,
+ * which executes components sequentially in the order they appear in the configuration.
+ *
+ * == Custom Implementations ==
+ *
+ * You can create custom runners for specialized behavior:
+ * - Parallel execution of independent components
+ * - Dry-run mode that validates without executing
+ * - Conditional execution based on external state
+ *
+ * == Example ==
+ *
+ * {{{
+ * // Using the standard runner with custom hooks
+ * val hooks = new PipelineHooks {
+ *   override def afterComponent(config: ComponentConfig, index: Int, total: Int, durationMs: Long): Unit =
+ *     println(s"Component $${config.instanceName} completed in $${durationMs}ms")
+ * }
+ *
+ * SimplePipelineRunner.run(config, hooks)
+ * }}}
+ */
+trait PipelineRunner {
+
+  /**
+   * Runs the pipeline defined in the given configuration.
+   *
+   * This is a convenience method that uses `PipelineHooks.NoOp`.
+   *
+   * May throw `ComponentInstantiationException` if a component cannot be instantiated,
+   * or `ConfigReaderException` if the configuration is invalid.
+   *
+   * @param config The loaded HOCON configuration containing `pipeline` and optionally `spark` blocks
+   */
+  def run(config: Config): Unit = run(config, PipelineHooks.NoOp)
+
+  /**
+   * Runs the pipeline defined in the given configuration with lifecycle hooks.
+   *
+   * May throw `ComponentInstantiationException` if a component cannot be instantiated,
+   * or `ConfigReaderException` if the configuration is invalid.
+   *
+   * @param config The loaded HOCON configuration containing `pipeline` and optionally `spark` blocks
+   * @param hooks Lifecycle hooks to invoke during execution
+   */
+  def run(config: Config, hooks: PipelineHooks): Unit
+}

--- a/runner/src/main/scala/io/github/dwsmith1983/spark/pipeline/runner/package.scala
+++ b/runner/src/main/scala/io/github/dwsmith1983/spark/pipeline/runner/package.scala
@@ -5,7 +5,24 @@ package io.github.dwsmith1983.spark.pipeline
  *
  * This package provides the entry point for executing pipelines:
  *
- * - [[runner.SimplePipelineRunner]] - Main class for spark-submit
+ * - [[runner.PipelineRunner]] - Trait defining the pipeline execution interface
+ * - [[runner.SimplePipelineRunner]] - Main class for spark-submit (sequential execution)
+ *
+ * == Lifecycle Hooks ==
+ *
+ * Use `PipelineHooks` from the config package to monitor
+ * or customize pipeline execution:
+ *
+ * {{{
+ * import io.github.dwsmith1983.spark.pipeline.config._
+ *
+ * val hooks = new PipelineHooks {
+ *   override def afterComponent(config: ComponentConfig, index: Int, total: Int, durationMs: Long): Unit =
+ *     println(s"Component $${config.instanceName} completed in $${durationMs}ms")
+ * }
+ *
+ * SimplePipelineRunner.run(config, hooks)
+ * }}}
  *
  * == Deployment ==
  *

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Pre-commit hook for spark-pipeline-framework
+# Runs scalafmt and scalastyle checks before committing
+#
+# Installation:
+#   Option 1: Copy to .git/hooks/pre-commit
+#     cp scripts/pre-commit.sh .git/hooks/pre-commit
+#     chmod +x .git/hooks/pre-commit
+#
+#   Option 2: Use pre-commit framework (requires Python)
+#     pip install pre-commit
+#     pre-commit install
+#
+
+set -e
+
+echo "Running pre-commit checks..."
+
+# Check if sbt is available
+if ! command -v sbt &> /dev/null; then
+    echo "Error: sbt is not installed or not in PATH"
+    exit 1
+fi
+
+# Run scalafmt check
+echo "Checking formatting with scalafmt..."
+if ! sbt --error scalafmtCheckAll 2>&1; then
+    echo ""
+    echo "Scalafmt check failed. Run 'sbt scalafmtAll' to fix formatting."
+    exit 1
+fi
+
+# Run scalastyle check
+echo "Checking style with scalastyle..."
+if ! sbt --error scalastyle 2>&1; then
+    echo ""
+    echo "Scalastyle check failed. Please fix the style issues above."
+    exit 1
+fi
+
+echo "All pre-commit checks passed!"


### PR DESCRIPTION
## Summary

   - **PipelineRunner trait**: Standard interface for pipeline executors with optional hooks
   - **PipelineHooks trait**: Lifecycle callbacks for monitoring and custom behavior
     - `beforePipeline` / `afterPipeline`
     - `beforeComponent` / `afterComponent`
     - `onComponentFailure`
   - **PipelineResult sealed trait**: Type-safe `Success`/`Failure` results with execution details
   - **Composable hooks**: `PipelineHooks.compose()` to combine multiple hooks
   - **Backward compatible**: Existing `run(config)` API continues to work
   - **End-to-end demo**: MetricsHooks example + DemoPipeline showcasing hooks, metrics, and multi-component
   pipelines
   - **README updated**: Documentation with sample output showing the demo in action