### PR TITLE
feat: add Maven Central publishing support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,8 @@ on:
 
 jobs:
   publish:
-    name: Publish to GitHub Packages
+    name: Publish to Maven Central
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,7 +22,17 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Publish packages
+      - name: Import PGP Key
+        run: |
+          echo "${{ secrets.PGP_SECRET }}" | base64 --decode | gpg --batch --import
+          gpg --list-secret-keys --keyid-format=long
+
+      - name: Publish to Maven Central
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: sbt publish
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+        run: |
+          sbt 'set ThisBuild / publishConfiguration := publishConfiguration.value.withOverwrite(true)' \
+              +publishSigned \
+              sonatypeBundleRelease

--- a/build.sbt
+++ b/build.sbt
@@ -20,17 +20,8 @@ ThisBuild / organization := "io.github.dwsmith1983"
 ThisBuild / version := "0.1.3" // x-release-please-version
 ThisBuild / javacOptions ++= Seq("-source", "17", "-target", "17")
 
-// GitHub Packages publishing
-ThisBuild / publishTo := Some(
-  "GitHub Packages" at "https://maven.pkg.github.com/dwsmith1983/spark-pipeline-framework"
-)
+// Publishing configuration
 ThisBuild / publishMavenStyle := true
-ThisBuild / credentials += Credentials(
-  "GitHub Package Registry",
-  "maven.pkg.github.com",
-  "dwsmith1983",
-  sys.env.getOrElse("GITHUB_TOKEN", "")
-)
 ThisBuild / licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0"))
 ThisBuild / homepage := Some(url("https://github.com/dwsmith1983/spark-pipeline-framework"))
 ThisBuild / scmInfo := Some(
@@ -42,6 +33,11 @@ ThisBuild / scmInfo := Some(
 ThisBuild / developers := List(
   Developer("dwsmith1983", "Dustin Smith", "Dustin.William.Smith@gmail.com", url("https://github.com/dwsmith1983"))
 )
+
+// Maven Central (Sonatype) publishing via Central Portal
+ThisBuild / sonatypeCredentialHost := "central.sonatype.com"
+ThisBuild / sonatypeRepository := "https://central.sonatype.com/api/v1/publisher"
+ThisBuild / publishTo := sonatypePublishToBundle.value
 
 // Resolve dependency conflicts
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,3 +15,7 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 // Code coverage
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.12")
+
+// Maven Central publishing
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")


### PR DESCRIPTION
## Summary

   Adds Maven Central publishing via Sonatype Central Portal, replacing GitHub Packages as the primary artifact
   repository.

   ### Changes
   - **plugins.sbt**: Added `sbt-sonatype` (3.10.0) and `sbt-pgp` (2.2.1)
   - **build.sbt**: Configured for Central Portal (`central.sonatype.com`)
   - **release.yml**: Updated workflow to import PGP key and publish signed artifacts

   ### Required Secrets (already configured)
   - `SONATYPE_USERNAME` - Sonatype user token username
   - `SONATYPE_PASSWORD` - Sonatype user token password
   - `PGP_SECRET` - Base64-encoded GPG private key
   - `PGP_PASSPHRASE` - GPG key passphrase