### PR TITLE
fix: use sonatypeCentralUpload for Central Portal publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,4 @@ jobs:
         run: |
           sbt 'set ThisBuild / publishConfiguration := publishConfiguration.value.withOverwrite(true)' \
               +publishSigned \
-              sonatypeBundleRelease
+              sonatypeCentralUpload

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # spark-pipeline-framework
 [![CI](https://github.com/dwsmith1983/spark-pipeline-framework/actions/workflows/ci.yml/badge.svg)](https://github.com/dwsmith1983/spark-pipeline-framework/actions/workflows/ci.yml)
-[![GitHub Packages](https://img.shields.io/badge/GitHub%20Packages-published-brightgreen?logo=github)](https://github.com/dwsmith1983?tab=packages&repo_name=spark-pipeline-framework)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.dwsmith1983/spark-pipeline-core_2.13?label=Maven%20Central)](https://central.sonatype.com/namespace/io.github.dwsmith1983)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Scala Versions](https://img.shields.io/badge/scala-2.12%20%7C%202.13-blue)](https://www.scala-lang.org)
 [![Spark Versions](https://img.shields.io/badge/spark-3.5.x%20%7C%204.0.x-E25A1C)](https://spark.apache.org)


### PR DESCRIPTION
## Summary
- Fix Maven Central publish workflow that failed with 404 error
- Replace `sonatypeBundleRelease` with `sonatypeCentralUpload` for Central Portal
- The new Sonatype Central Portal uses a different API than legacy OSSRH

## Context
The v0.1.4 release publish failed because `sonatypeBundleRelease` attempts to use staging repository endpoints
that don't exist on Central Portal. The `sonatypeCentralUpload` command is the correct one for Central Portal
publishing.