### PR TITLE
fix: upgrade sbt-sonatype to 3.12.2 for Central Portal support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,4 @@ jobs:
         run: |
           sbt 'set ThisBuild / publishConfiguration := publishConfiguration.value.withOverwrite(true)' \
               +publishSigned \
-              sonatypeCentralUpload
+              sonatypeCentralRelease

--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ A configuration-driven framework for building Spark pipelines with HOCON config 
 
 ### 1. Add dependency to your project
 
+Available on [Maven Central](https://central.sonatype.com/namespace/io.github.dwsmith1983):
+
 ```scala
-// build.sbt
-libraryDependencies += "io.github.dwsmith1983" %% "spark-pipeline-runtime-spark3" % "0.1.0"
+// build.sbt - no resolver needed, Maven Central is the default
+libraryDependencies += "io.github.dwsmith1983" %% "spark-pipeline-runtime-spark3" % "<version>"
 ```
 
 ### 2. Create a pipeline component

--- a/build.sbt
+++ b/build.sbt
@@ -35,8 +35,8 @@ ThisBuild / developers := List(
 )
 
 // Maven Central (Sonatype) publishing via Central Portal
-ThisBuild / sonatypeCredentialHost := "central.sonatype.com"
-ThisBuild / sonatypeRepository := "https://central.sonatype.com/api/v1/publisher"
+import xerial.sbt.Sonatype.sonatypeCentralHost
+ThisBuild / sonatypeCredentialHost := sonatypeCentralHost
 ThisBuild / publishTo := sonatypePublishToBundle.value
 
 // Resolve dependency conflicts

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,5 +17,5 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.12")
 
 // Maven Central publishing
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")


### PR DESCRIPTION
## Summary
- Upgrade sbt-sonatype from 3.10.0 to 3.12.2
- Use `sonatypeCentralHost` import for proper Central Portal config
- Use `sonatypeCentralRelease` command (added in 3.11.0)
- Update README to clarify Maven Central availability

## Context
The v0.1.5 publish failed because `sonatypeCentralUpload` doesn't exist in sbt-sonatype 3.10.0.
Central Portal support (`sonatypeCentralRelease`) was added in sbt-sonatype 3.11.0.

See: https://github.com/xerial/sbt-sonatype