### PR TITLE
fix: improve Scaladoc copy and update homepage URL

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,17 +38,36 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Generate Scaladoc
-        run: sbt doc
+        run: |
+          # Generate docs for Scala 2.13 / Spark 3 variants
+          sbt "core/doc" "runtimespark3/doc" "runnerspark3/doc"
 
       - name: Copy Scaladoc to website
         run: |
           mkdir -p website/static/api
-          # Copy core module docs
-          cp -r core/target/jvm-2.13/api/* website/static/api/ 2>/dev/null || true
-          # Copy runtime module docs (spark3 as default)
-          cp -r runtime/target/spark3-jvm-2.13/api/* website/static/api/ 2>/dev/null || true
-          # Copy runner module docs
-          cp -r runner/target/spark3-jvm-2.13/api/* website/static/api/ 2>/dev/null || true
+
+          # Find and list available API directories for debugging
+          echo "Available API directories:"
+          find . -type d -name "api" -path "*/target/*" | head -20
+
+          # Copy from available locations (try multiple path patterns)
+          for module in core runtime runner; do
+            for path in "$module/target/jvm-2.13/api" "$module/target/spark3-jvm-2.13/api" "$module/target/scala-2.13/api"; do
+              if [ -d "$path" ] && [ -f "$path/index.html" ]; then
+                echo "Copying from $path"
+                cp -r "$path"/* website/static/api/
+              fi
+            done
+          done
+
+          # Verify API files were copied
+          echo "Files in website/static/api:"
+          ls -la website/static/api/ || echo "WARNING: No files in static/api"
+
+          if [ ! -f "website/static/api/index.html" ]; then
+            echo "ERROR: API index.html not found - Scaladoc copy failed"
+            exit 1
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ ThisBuild / javacOptions ++= Seq("-source", "17", "-target", "17")
 // Publishing configuration
 ThisBuild / publishMavenStyle := true
 ThisBuild / licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0"))
-ThisBuild / homepage := Some(url("https://github.com/dwsmith1983/spark-pipeline-framework"))
+ThisBuild / homepage := Some(url("https://dwsmith1983.github.io/spark-pipeline-framework/"))
 ThisBuild / scmInfo := Some(
   ScmInfo(
     url("https://github.com/dwsmith1983/spark-pipeline-framework"),


### PR DESCRIPTION
## Summary
- Fix the API 404 issue on the deployed GitHub Pages site by improving Scaladoc copy reliability
- Update Maven Central homepage to point to the documentation site

## Changes

### docs.yml workflow
- Generate docs explicitly for `core`, `runtimespark3`, and `runnerspark3` projects
- Add debugging output to show available API directories
- Use flexible path detection to find API docs regardless of path structure
- Add verification step that fails build if API index.html is missing
- Remove silent error suppression that was hiding copy failures

### build.sbt
- Update homepage URL from GitHub repo to GitHub Pages documentation site