### PR TITLE
feat: add dry-run validation and continue-on-error mode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -252,8 +252,8 @@ lazy val example = (projectMatrix in file("example"))
     name := "spark-pipeline-example",
     commonSettings,
     publish / skip := true,
-    // Exclude DemoPipeline from coverage - it's a runnable demo with main()
-    coverageExcludedFiles := ".*DemoPipeline.*"
+    // Exclude demo files from coverage - runnable demos with main() don't need coverage
+    coverageExcludedFiles := ".*DemoPipeline.*;.*ValidationDemo.*;.*FailingComponent.*"
   )
   .customRow(
     scalaVersions = Seq(scala212),

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/ConfigModels.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/ConfigModels.scala
@@ -14,16 +14,20 @@ import com.typesafe.config.Config
  * {{{
  * pipeline {
  *   pipeline-name = "My Data Pipeline"
+ *   fail-fast = true  # Optional, defaults to true
  *   pipeline-components = [...]
  * }
  * }}}
  *
  * @param pipelineName Human-readable name for the pipeline
  * @param pipelineComponents List of components to execute in order
+ * @param failFast If true (default), stop on first component failure.
+ *                 If false, continue executing remaining components and report all failures.
  */
 case class PipelineConfig(
   pipelineName: String,
-  pipelineComponents: List[ComponentConfig])
+  pipelineComponents: List[ComponentConfig],
+  failFast: Boolean = true)
 
 /**
  * Configuration for a single pipeline component.

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/DryRunResult.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/DryRunResult.scala
@@ -1,0 +1,106 @@
+package io.github.dwsmith1983.spark.pipeline.config
+
+/**
+ * Result of a pipeline dry-run validation.
+ *
+ * A dry-run validates the pipeline configuration and component instantiation
+ * without actually executing the components. This is useful for CI/CD pipelines
+ * to validate configurations before deployment.
+ *
+ * == Example ==
+ *
+ * {{{
+ * val result = SimplePipelineRunner.dryRun(config)
+ * result match {
+ *   case DryRunResult.Valid(name, count, _) =>
+ *     println(s"Pipeline '$$name' is valid with $$count components")
+ *   case DryRunResult.Invalid(errors) =>
+ *     errors.foreach(e => println(s"Error: $$e"))
+ *     sys.exit(1)
+ * }
+ * }}}
+ */
+sealed trait DryRunResult {
+
+  /** Whether the dry-run validation passed. */
+  def isValid: Boolean
+
+  /** Whether the dry-run validation failed. */
+  def isInvalid: Boolean = !isValid
+}
+
+object DryRunResult {
+
+  /**
+   * Indicates the pipeline configuration is valid.
+   *
+   * All components were successfully instantiated, meaning:
+   * - The configuration parses correctly
+   * - All component classes exist and are accessible
+   * - All component companion objects have valid `createFromConfig` methods
+   * - All component configurations are valid
+   *
+   * @param pipelineName The name of the validated pipeline
+   * @param componentCount Number of components in the pipeline
+   * @param components The validated component configurations
+   */
+  final case class Valid(
+    pipelineName: String,
+    componentCount: Int,
+    components: List[ComponentConfig])
+    extends DryRunResult {
+    override def isValid: Boolean = true
+  }
+
+  /**
+   * Indicates the pipeline configuration is invalid.
+   *
+   * @param errors List of validation errors encountered
+   */
+  final case class Invalid(errors: List[DryRunError]) extends DryRunResult {
+    override def isValid: Boolean = false
+  }
+}
+
+/** Error encountered during dry-run validation. */
+sealed trait DryRunError {
+
+  /** Human-readable description of the error. */
+  def message: String
+
+  /** The underlying cause, if any. */
+  def cause: Option[Throwable]
+}
+
+object DryRunError {
+
+  /**
+   * Error parsing the pipeline or Spark configuration.
+   *
+   * @param message Description of the parse error
+   * @param underlying The underlying exception
+   */
+  final case class ConfigParseError(message: String, underlying: Throwable) extends DryRunError {
+    override def cause: Option[Throwable] = Some(underlying)
+  }
+
+  /**
+   * Error instantiating a pipeline component.
+   *
+   * This typically means the component class doesn't exist, doesn't have
+   * a companion object with `createFromConfig`, or the component's
+   * configuration is invalid.
+   *
+   * @param component The component configuration that failed
+   * @param underlying The underlying exception
+   */
+  final case class ComponentInstantiationError(
+    component: ComponentConfig,
+    underlying: Throwable)
+    extends DryRunError {
+
+    override def message: String =
+      s"Failed to instantiate component '${component.instanceName}' (${component.instanceType}): ${underlying.getMessage}"
+    override def cause: Option[Throwable] = Some(underlying)
+  }
+}

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/LoggingHooks.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/LoggingHooks.scala
@@ -95,6 +95,8 @@ class LoggingHooks(
         ("success", duration, completed)
       case PipelineResult.Failure(_, _, completed) =>
         ("failure", System.currentTimeMillis() - pipelineStartTime, completed)
+      case PipelineResult.PartialSuccess(duration, succeeded, failed, _) =>
+        ("partial_success", duration, succeeded + failed)
     }
 
     if (useStructuredFormat) {

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/PipelineResult.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/PipelineResult.scala
@@ -40,4 +40,24 @@ object PipelineResult {
     extends PipelineResult {
     override def isSuccess: Boolean = false
   }
+
+  /**
+   * Indicates partial pipeline completion when `failFast = false`.
+   *
+   * Some components succeeded while others failed. The pipeline continued
+   * execution after failures instead of stopping at the first error.
+   *
+   * @param durationMs Total pipeline execution time in milliseconds
+   * @param componentsSucceeded Number of components that completed successfully
+   * @param componentsFailed Number of components that failed
+   * @param failures List of failed components with their errors
+   */
+  final case class PartialSuccess(
+    durationMs: Long,
+    componentsSucceeded: Int,
+    componentsFailed: Int,
+    failures: List[(ComponentConfig, Throwable)])
+    extends PipelineResult {
+    override def isSuccess: Boolean = false
+  }
 }

--- a/example/src/main/scala/io/github/dwsmith1983/pipelines/DemoPipeline.scala
+++ b/example/src/main/scala/io/github/dwsmith1983/pipelines/DemoPipeline.scala
@@ -124,6 +124,9 @@ object DemoPipeline {
               println(s"\n[PIPELINE FAILED] After $completed components")
               failed.foreach(c => println(s"  Failed component: ${c.instanceName}"))
               println(s"  Error: ${error.getMessage}")
+            case PipelineResult.PartialSuccess(duration, succeeded, failed, failures) =>
+              println(s"\n[PIPELINE PARTIAL] $succeeded succeeded, $failed failed in ${duration}ms")
+              failures.foreach { case (c, e) => println(s"  Failed: ${c.instanceName} - ${e.getMessage}") }
           }
         }
 

--- a/example/src/main/scala/io/github/dwsmith1983/pipelines/MetricsHooks.scala
+++ b/example/src/main/scala/io/github/dwsmith1983/pipelines/MetricsHooks.scala
@@ -85,8 +85,9 @@ class MetricsHooks extends PipelineHooks {
   override def afterPipeline(config: PipelineConfig, result: PipelineResult): Unit = {
     val _ = config // suppress unused warning
     _totalDurationMs = result match {
-      case PipelineResult.Success(duration, _) => duration
-      case PipelineResult.Failure(_, _, _)     => System.currentTimeMillis() - _pipelineStartTime
+      case PipelineResult.Success(duration, _)              => duration
+      case PipelineResult.Failure(_, _, _)                  => System.currentTimeMillis() - _pipelineStartTime
+      case PipelineResult.PartialSuccess(duration, _, _, _) => duration
     }
   }
 

--- a/example/src/main/scala/io/github/dwsmith1983/pipelines/ValidationDemo.scala
+++ b/example/src/main/scala/io/github/dwsmith1983/pipelines/ValidationDemo.scala
@@ -1,0 +1,237 @@
+package io.github.dwsmith1983.pipelines
+
+import io.github.dwsmith1983.spark.pipeline.config._
+import io.github.dwsmith1983.spark.pipeline.runner.SimplePipelineRunner
+import com.typesafe.config.ConfigFactory
+
+import java.nio.file.{Files, Path}
+
+/**
+ * Demonstrates dry-run validation and continue-on-error mode.
+ *
+ * This example shows:
+ * - Validating pipeline configs without execution using `dryRun()`
+ * - Running pipelines with `fail-fast = false` to continue after failures
+ * - Handling `PartialSuccess` results
+ *
+ * == Running ==
+ *
+ * {{{
+ * sbt "examplespark3/runMain io.github.dwsmith1983.pipelines.ValidationDemo"
+ * }}}
+ */
+object ValidationDemo {
+
+  def main(args: Array[String]): Unit = {
+    println("=" * 70)
+    println("  VALIDATION & ERROR HANDLING DEMO")
+    println("=" * 70)
+
+    val tempDir: Path = Files.createTempDirectory("validation-demo")
+
+    try {
+      demoDryRun(tempDir)
+      println()
+      demoContinueOnError(tempDir)
+    } finally {
+      Files.walk(tempDir)
+        .sorted(java.util.Comparator.reverseOrder())
+        .forEach { (p: Path) =>
+          val _: Boolean = Files.deleteIfExists(p)
+        }
+    }
+  }
+
+  /** Demonstrates dry-run validation. */
+  private def demoDryRun(tempDir: Path): Unit = {
+    println("\n" + "-" * 70)
+    println("  PART 1: DRY-RUN VALIDATION")
+    println("-" * 70)
+
+    val inputFile: Path = tempDir.resolve("input.txt")
+    Files.writeString(inputFile, "hello world")
+
+    // Valid configuration
+    val validConfig = ConfigFactory.parseString(s"""
+      spark {
+        master = "local[*]"
+        app-name = "DryRun Demo"
+        config { "spark.ui.enabled" = "false" }
+      }
+      pipeline {
+        pipeline-name = "Valid Pipeline"
+        pipeline-components = [
+          {
+            instance-type = "io.github.dwsmith1983.pipelines.WordCount"
+            instance-name = "WordCount"
+            instance-config {
+              input-path = "${inputFile.toString.replace("\\", "/")}"
+              output-path = "${tempDir.resolve("output").toString.replace("\\", "/")}"
+            }
+          }
+        ]
+      }
+    """)
+
+    println("\n[TEST 1] Validating correct configuration...")
+    SimplePipelineRunner.dryRun(validConfig) match {
+      case DryRunResult.Valid(name, count, _) =>
+        println(s"  ✓ Pipeline '$name' is valid with $count component(s)")
+      case DryRunResult.Invalid(errors) =>
+        println(s"  ✗ Unexpected validation failure: ${errors.size} error(s)")
+    }
+
+    // Invalid configuration - nonexistent component class
+    val invalidConfig = ConfigFactory.parseString("""
+      spark {
+        master = "local[*]"
+        app-name = "Invalid Demo"
+        config { "spark.ui.enabled" = "false" }
+      }
+      pipeline {
+        pipeline-name = "Invalid Pipeline"
+        pipeline-components = [
+          {
+            instance-type = "com.nonexistent.FakeComponent"
+            instance-name = "Ghost"
+            instance-config {}
+          },
+          {
+            instance-type = "also.does.not.Exist"
+            instance-name = "AnotherGhost"
+            instance-config {}
+          }
+        ]
+      }
+    """)
+
+    println("\n[TEST 2] Validating configuration with invalid components...")
+    SimplePipelineRunner.dryRun(invalidConfig) match {
+      case DryRunResult.Valid(_, _, _) =>
+        println("  ✗ Unexpected success")
+      case DryRunResult.Invalid(errors) =>
+        println(s"  ✓ Caught ${errors.size} validation error(s):")
+        errors.foreach(error => println(s"    - ${error.message.take(60)}..."))
+    }
+
+    println("\n[RESULT] Dry-run validates configs without executing components")
+  }
+
+  /** Demonstrates continue-on-error mode with fail-fast = false. */
+  private def demoContinueOnError(tempDir: Path): Unit = {
+    println("\n" + "-" * 70)
+    println("  PART 2: CONTINUE-ON-ERROR MODE")
+    println("-" * 70)
+
+    val inputFile: Path = tempDir.resolve("input2.txt")
+    Files.writeString(inputFile, "testing continue on error mode")
+
+    // Pipeline with fail-fast = false and a failing component
+    val config = ConfigFactory.parseString(s"""
+      spark {
+        master = "local[*]"
+        app-name = "ContinueOnError Demo"
+        config { "spark.ui.enabled" = "false" }
+      }
+      pipeline {
+        pipeline-name = "Resilient Pipeline"
+        fail-fast = false
+        pipeline-components = [
+          {
+            instance-type = "io.github.dwsmith1983.pipelines.WordCount"
+            instance-name = "Step1-WordCount"
+            instance-config {
+              input-path = "${inputFile.toString.replace("\\", "/")}"
+              output-path = "${tempDir.resolve("step1").toString.replace("\\", "/")}"
+            }
+          },
+          {
+            instance-type = "io.github.dwsmith1983.pipelines.FailingComponent"
+            instance-name = "Step2-WillFail"
+            instance-config {
+              error-message = "Simulated failure for demo"
+            }
+          },
+          {
+            instance-type = "io.github.dwsmith1983.pipelines.WordCount"
+            instance-name = "Step3-WordCount"
+            instance-config {
+              input-path = "${inputFile.toString.replace("\\", "/")}"
+              output-path = "${tempDir.resolve("step3").toString.replace("\\", "/")}"
+            }
+          }
+        ]
+      }
+    """)
+
+    println("\n[RUNNING] Pipeline with fail-fast = false...")
+    println("          (Step 2 will fail, but Step 3 should still run)")
+    println()
+
+    var finalResult: PipelineResult = null
+
+    val hooks = new PipelineHooks {
+      override def beforeComponent(config: ComponentConfig, index: Int, total: Int): Unit =
+        println(s"  [${index + 1}/$total] Starting: ${config.instanceName}")
+
+      override def afterComponent(
+        config: ComponentConfig,
+        index: Int,
+        total: Int,
+        durationMs: Long
+      ): Unit =
+        println(s"  [${index + 1}/$total] ✓ Completed: ${config.instanceName}")
+
+      override def onComponentFailure(config: ComponentConfig, index: Int, error: Throwable): Unit =
+        println(s"  [${index + 1}] ✗ Failed: ${config.instanceName} - ${error.getMessage}")
+
+      override def afterPipeline(config: PipelineConfig, result: PipelineResult): Unit =
+        finalResult = result
+    }
+
+    SimplePipelineRunner.run(config, hooks)
+
+    println()
+    finalResult match {
+      case PipelineResult.Success(duration, count) =>
+        println(s"[RESULT] Success: $count components in ${duration}ms")
+
+      case PipelineResult.PartialSuccess(duration, succeeded, failed, failures) =>
+        println(s"[RESULT] PartialSuccess in ${duration}ms:")
+        println(s"         ✓ $succeeded component(s) succeeded")
+        println(s"         ✗ $failed component(s) failed:")
+        failures.foreach {
+          case (comp, err) =>
+            println(s"           - ${comp.instanceName}: ${err.getMessage}")
+        }
+
+      case PipelineResult.Failure(error, comp, completed) =>
+        println(s"[RESULT] Failure after $completed components")
+        comp.foreach(c => println(s"         Failed at: ${c.instanceName}"))
+        println(s"         Error: ${error.getMessage}")
+    }
+
+    println("\n[NOTE] With fail-fast = true (default), Step 3 would NOT have run")
+  }
+}
+
+/** A component that always fails - for testing error handling. */
+case class FailingComponentConfig(errorMessage: String)
+
+object FailingComponent extends ConfigurableInstance {
+
+  import pureconfig._
+  import pureconfig.generic.auto._
+
+  override def createFromConfig(conf: com.typesafe.config.Config): FailingComponent = {
+    val config = ConfigSource.fromConfig(conf).loadOrThrow[FailingComponentConfig]
+    new FailingComponent(config)
+  }
+}
+
+class FailingComponent(conf: FailingComponentConfig)
+  extends io.github.dwsmith1983.spark.pipeline.runtime.DataFlow {
+
+  override def run(): Unit =
+    throw new RuntimeException(conf.errorMessage)
+}

--- a/runner/src/main/scala/io/github/dwsmith1983/spark/pipeline/runner/PipelineRunner.scala
+++ b/runner/src/main/scala/io/github/dwsmith1983/spark/pipeline/runner/PipelineRunner.scala
@@ -1,7 +1,7 @@
 package io.github.dwsmith1983.spark.pipeline.runner
 
 import com.typesafe.config.Config
-import io.github.dwsmith1983.spark.pipeline.config.PipelineHooks
+import io.github.dwsmith1983.spark.pipeline.config.{DryRunResult, PipelineHooks}
 
 /**
  * Trait defining the interface for pipeline execution.
@@ -60,4 +60,31 @@ trait PipelineRunner {
    * @param hooks Lifecycle hooks to invoke during execution
    */
   def run(config: Config, hooks: PipelineHooks): Unit
+
+  /**
+   * Validates the pipeline configuration without executing components.
+   *
+   * This method parses the configuration and instantiates all components
+   * to verify they can be created, but does not call their `run()` methods.
+   * Useful for CI/CD pipelines to validate configurations before deployment.
+   *
+   * This is a convenience method that uses `PipelineHooks.NoOp`.
+   *
+   * @param config The loaded HOCON configuration containing `pipeline` and optionally `spark` blocks
+   * @return Validation result indicating success or listing errors
+   */
+  def dryRun(config: Config): DryRunResult = dryRun(config, PipelineHooks.NoOp)
+
+  /**
+   * Validates the pipeline configuration without executing components.
+   *
+   * This method parses the configuration and instantiates all components
+   * to verify they can be created, but does not call their `run()` methods.
+   * Lifecycle hooks are invoked for `beforePipeline` and `afterPipeline` only.
+   *
+   * @param config The loaded HOCON configuration containing `pipeline` and optionally `spark` blocks
+   * @param hooks Lifecycle hooks to invoke (only beforePipeline/afterPipeline are called)
+   * @return Validation result indicating success or listing errors
+   */
+  def dryRun(config: Config, hooks: PipelineHooks): DryRunResult
 }

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -79,6 +79,28 @@ pipeline {
 |-------|------|----------|-------------|
 | `pipeline-name` | String | Yes | Human-readable pipeline name |
 | `pipeline-components` | List | Yes | Ordered list of components to execute |
+| `fail-fast` | Boolean | No | If `true` (default), stop on first component failure. If `false`, continue executing remaining components and report all failures. |
+
+### Error Handling Modes
+
+By default, the pipeline stops immediately when a component fails (`fail-fast = true`). You can change this behavior to continue execution despite failures:
+
+```json
+pipeline {
+  pipeline-name = "Resilient Pipeline"
+  fail-fast = false  // Continue after component failures
+
+  pipeline-components = [
+    // Components will all be attempted even if some fail
+  ]
+}
+```
+
+When `fail-fast = false`:
+- All components are attempted regardless of earlier failures
+- `onComponentFailure` hook is called for each failed component
+- Pipeline returns `PartialSuccess` result with details of all failures
+- Useful for batch processing where some failures are acceptable
 
 ### ComponentConfig Fields
 

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -8,6 +8,8 @@ Spark Pipeline Framework is a configuration-driven framework for building Apache
 - **SparkSession management** from config files
 - **Dynamic component instantiation** via reflection (no compile-time coupling)
 - **Lifecycle hooks** for monitoring, metrics, and custom error handling
+- **Dry-run validation** to verify configs without executing pipelines
+- **Flexible error handling** with fail-fast or continue-on-error modes
 - **Cross-compilation** support for Spark 3.x and 4.x
 
 ## Installation


### PR DESCRIPTION
## Summary

   Completes Phase B of the roadmap by adding:

   - **Dry-run mode**: Validate pipeline configs without executing components
     - `dryRun()` and `dryRunFromFile()` methods on `SimplePipelineRunner`
     - `DryRunResult` sealed trait with `Valid`/`Invalid` variants
     - Collects all validation errors instead of stopping at first

   - **Continue-on-error mode**: Run all components even if some fail
     - `failFast: Boolean = true` config option in `PipelineConfig`
     - `PartialSuccess` result variant for tracking partial failures
     - Hooks still called for each failure

   ## Changes

   | Area | Files | Description |
   |------|-------|-------------|
   | Core | `DryRunResult.scala` | New sealed trait for dry-run results |
   | Core | `ConfigModels.scala` | Added `failFast` field |
   | Core | `PipelineResult.scala` | Added `PartialSuccess` variant |
   | Runner | `PipelineRunner.scala` | Added `dryRun()` methods |
   | Runner | `SimplePipelineRunner.scala` | Implemented both features |
   | Example | `ValidationDemo.scala` | New demo showing both features |
   | Docs | `configuration.md`, `hooks.md`, `getting-started.md` | Updated documentation |
   | Tests | `SimplePipelineRunnerSpec.scala` | 8 new tests |