### PR TITLE
chore: skip tests and security scan for release-please PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    # Skip for release-please PRs (version bump only, code already passed CI on main)
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -93,6 +95,8 @@ jobs:
     name: Test (Spark 3 / Scala 2.12)
     runs-on: ubuntu-latest
     needs: lint
+    # Skip for release-please PRs (version bump only, code already passed CI on main)
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -117,6 +121,8 @@ jobs:
     name: Test (Spark 3 / Scala 2.13)
     runs-on: ubuntu-latest
     needs: lint
+    # Skip for release-please PRs (version bump only, code already passed CI on main)
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -141,6 +147,8 @@ jobs:
     name: Test (Spark 4 / Scala 2.13)
     runs-on: ubuntu-latest
     needs: lint
+    # Skip for release-please PRs (version bump only, code already passed CI on main)
+    if: ${{ !startsWith(github.head_ref, 'release-please') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Skip test jobs and security scan for release-please PRs
- Keep lint to validate version format changes

## Rationale

Release-please PRs only change:
- `CHANGELOG.md`
- Version in `build.sbt`

The code already passed full CI when merged to main. Running the full test suite again (~10+ minutes) is redundant.

## Changes

Added `if: ${{ !startsWith(github.head_ref, 'release-please') }}` to:
- `security` job
- `test-spark3` job  
- `test-spark3-scala213` job
- `test-spark4` job

Lint still runs to catch any formatting issues in version changes.