### PR TITLE
test: add ScalaCheck property-based tests for config parsing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ lazy val spark40 = "4.0.1"
 lazy val typesafeConfigVersion = "1.4.3"
 lazy val pureConfigVersion = "0.17.4"
 lazy val scalatestVersion = "3.2.17"
+lazy val scalacheckVersion = "1.17.0"
 lazy val log4jVersion = "2.23.1"
 lazy val micrometerVersion = "1.12.2"
 
@@ -157,7 +158,9 @@ lazy val commonSettings = Seq(
   Compile / console / scalacOptions --= Seq("-Xfatal-warnings"),
   Test / scalacOptions --= Seq("-Xfatal-warnings"),
   libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % scalatestVersion % Test
+    "org.scalatest" %% "scalatest" % scalatestVersion % Test,
+    "org.scalacheck" %% "scalacheck" % scalacheckVersion % Test,
+    "org.scalatestplus" %% "scalacheck-1-17" % "3.2.17.0" % Test
   ),
   // Scalastyle configuration - use root directory for config file
   (Compile / scalastyleConfig) := (ThisBuild / baseDirectory).value / "scalastyle-config.xml",

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/DryRunResult.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/DryRunResult.scala
@@ -99,8 +99,12 @@ object DryRunError {
     underlying: Throwable)
     extends DryRunError {
 
-    override def message: String =
-      s"Failed to instantiate component '${component.instanceName}' (${component.instanceType}): ${underlying.getMessage}"
+    override def message: String = {
+      val name = component.instanceName
+      val typ  = component.instanceType
+      val err  = underlying.getMessage
+      s"Failed to instantiate component '$name' ($typ): $err"
+    }
     override def cause: Option[Throwable] = Some(underlying)
   }
 }

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/LoggingHooks.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/LoggingHooks.scala
@@ -100,16 +100,17 @@ class LoggingHooks(
     }
 
     if (useStructuredFormat) {
-      logger.info(
-        s"""{"event":"pipeline_end","run_id":"$runId","pipeline_name":"${escapeJson(
-            config.pipelineName
-          )}","duration_ms":$durationMs,"status":"$status","components_completed":$componentsCompleted,"timestamp":"$timestamp"}"""
-      )
+      val name = escapeJson(config.pipelineName)
+      val json = s"""{"event":"pipeline_end","run_id":"$runId",""" +
+        s""""pipeline_name":"$name","duration_ms":$durationMs,""" +
+        s""""status":"$status","components_completed":$componentsCompleted,""" +
+        s""""timestamp":"$timestamp"}"""
+      logger.info(json)
     } else {
       val statusText = if (status == "success") "completed" else "failed"
-      logger.info(
-        s"Pipeline '${config.pipelineName}' $statusText in ${durationMs}ms (run_id=$runId, completed=$componentsCompleted)"
-      )
+      val msg = s"Pipeline '${config.pipelineName}' $statusText in ${durationMs}ms " +
+        s"(run_id=$runId, completed=$componentsCompleted)"
+      logger.info(msg)
     }
   }
 
@@ -118,13 +119,13 @@ class LoggingHooks(
     val componentNumber = index + 1
 
     if (useStructuredFormat) {
-      logger.info(
-        s"""{"event":"component_start","run_id":"$runId","component_name":"${escapeJson(
-            config.instanceName
-          )}","component_type":"${escapeJson(
-            config.instanceType
-          )}","component_index":$componentNumber,"total_components":$total,"timestamp":"$timestamp"}"""
-      )
+      val name = escapeJson(config.instanceName)
+      val typ  = escapeJson(config.instanceType)
+      val json = s"""{"event":"component_start","run_id":"$runId",""" +
+        s""""component_name":"$name","component_type":"$typ",""" +
+        s""""component_index":$componentNumber,"total_components":$total,""" +
+        s""""timestamp":"$timestamp"}"""
+      logger.info(json)
     } else {
       logger.info(s"[$componentNumber/$total] Starting '${config.instanceName}'")
     }
@@ -140,13 +141,15 @@ class LoggingHooks(
     val componentNumber = index + 1
 
     if (useStructuredFormat) {
-      logger.info(
-        s"""{"event":"component_end","run_id":"$runId","component_name":"${escapeJson(
-            config.instanceName
-          )}","component_index":$componentNumber,"total_components":$total,"duration_ms":$durationMs,"status":"success","timestamp":"$timestamp"}"""
-      )
+      val name = escapeJson(config.instanceName)
+      val json = s"""{"event":"component_end","run_id":"$runId",""" +
+        s""""component_name":"$name","component_index":$componentNumber,""" +
+        s""""total_components":$total,"duration_ms":$durationMs,""" +
+        s""""status":"success","timestamp":"$timestamp"}"""
+      logger.info(json)
     } else {
-      logger.info(s"[$componentNumber/$total] Completed '${config.instanceName}' in ${durationMs}ms")
+      val msg = s"[$componentNumber/$total] Completed '${config.instanceName}' in ${durationMs}ms"
+      logger.info(msg)
     }
   }
 
@@ -161,17 +164,17 @@ class LoggingHooks(
     componentStartTimes.remove(index)
 
     if (useStructuredFormat) {
-      logger.error(
-        s"""{"event":"component_error","run_id":"$runId","component_name":"${escapeJson(
-            config.instanceName
-          )}","component_index":$componentNumber,"duration_ms":$durationMs,"error_type":"$errorType","error_message":"${escapeJson(
-            errorMessage
-          )}","timestamp":"$timestamp"}"""
-      )
+      val name   = escapeJson(config.instanceName)
+      val errMsg = escapeJson(errorMessage)
+      val json = s"""{"event":"component_error","run_id":"$runId",""" +
+        s""""component_name":"$name","component_index":$componentNumber,""" +
+        s""""duration_ms":$durationMs,"error_type":"$errorType",""" +
+        s""""error_message":"$errMsg","timestamp":"$timestamp"}"""
+      logger.error(json)
     } else {
-      logger.error(
-        s"[$componentNumber] Component '${config.instanceName}' failed after ${durationMs}ms: $errorType - $errorMessage"
-      )
+      val msg = s"[$componentNumber] Component '${config.instanceName}' failed " +
+        s"after ${durationMs}ms: $errorType - $errorMessage"
+      logger.error(msg)
     }
   }
 }

--- a/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/config/ConfigParsingPropertySpec.scala
+++ b/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/config/ConfigParsingPropertySpec.scala
@@ -1,0 +1,360 @@
+package io.github.dwsmith1983.spark.pipeline.config
+
+import com.typesafe.config.ConfigFactory
+import org.scalacheck.Gen
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import pureconfig._
+import pureconfig.generic.auto._
+
+import PropertyTestGenerators._
+
+/**
+ * Property-based tests for config model parsing.
+ *
+ * These tests verify that config parsing works correctly for a wide range
+ * of randomly generated inputs, catching edge cases that example-based
+ * tests might miss.
+ *
+ * Properties tested:
+ * - Roundtrip: generated HOCON parses to expected values
+ * - Component order preservation
+ * - Optional field handling
+ * - Type safety (invalid types rejected)
+ * - Edge cases (empty names, special characters)
+ */
+class ConfigParsingPropertySpec extends AnyFunSpec with Matchers with ScalaCheckPropertyChecks {
+
+  // Increase the number of test cases for thorough coverage
+  override implicit val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 100)
+
+  describe("PipelineConfig property tests") {
+
+    describe("roundtrip parsing") {
+
+      it("should parse any valid pipeline model to expected values") {
+        forAll(genPipelineModel) { model =>
+          val hocon  = ConfigFactory.parseString(model.toHocon)
+          val result = ConfigSource.fromConfig(hocon).load[PipelineConfig]
+
+          result.isRight shouldBe true
+          val config = result.toOption.get
+
+          config.pipelineName shouldBe model.pipelineName
+          config.pipelineComponents should have size model.pipelineComponents.size
+          config.failFast shouldBe model.failFast
+        }
+      }
+
+      it("should preserve component order") {
+        forAll(genNonEmptyPipelineModel) { model =>
+          val hocon  = ConfigFactory.parseString(model.toHocon)
+          val result = ConfigSource.fromConfig(hocon).load[PipelineConfig]
+
+          result.isRight shouldBe true
+          val config = result.toOption.get
+
+          val expectedNames = model.pipelineComponents.map(_.instanceName)
+          val actualNames   = config.pipelineComponents.map(_.instanceName)
+
+          actualNames shouldBe expectedNames
+        }
+      }
+
+      it("should preserve component instance types") {
+        forAll(genNonEmptyPipelineModel) { model =>
+          val hocon  = ConfigFactory.parseString(model.toHocon)
+          val result = ConfigSource.fromConfig(hocon).load[PipelineConfig]
+
+          result.isRight shouldBe true
+          val config = result.toOption.get
+
+          val expectedTypes = model.pipelineComponents.map(_.instanceType)
+          val actualTypes   = config.pipelineComponents.map(_.instanceType)
+
+          actualTypes shouldBe expectedTypes
+        }
+      }
+    }
+
+    describe("failFast handling") {
+
+      it("should correctly parse failFast=true") {
+        forAll(genPipelineModel) { model =>
+          val modelWithFailFast = model.copy(failFast = true)
+          val hocon             = ConfigFactory.parseString(modelWithFailFast.toHocon)
+          val result            = ConfigSource.fromConfig(hocon).load[PipelineConfig]
+
+          result.isRight shouldBe true
+          result.toOption.get.failFast shouldBe true
+        }
+      }
+
+      it("should correctly parse failFast=false") {
+        forAll(genPipelineModel) { model =>
+          val modelWithFailFast = model.copy(failFast = false)
+          val hocon             = ConfigFactory.parseString(modelWithFailFast.toHocon)
+          val result            = ConfigSource.fromConfig(hocon).load[PipelineConfig]
+
+          result.isRight shouldBe true
+          result.toOption.get.failFast shouldBe false
+        }
+      }
+    }
+
+    describe("empty components list") {
+
+      it("should handle pipelines with no components") {
+        forAll(genPipelineModel) { model =>
+          val emptyModel = model.copy(pipelineComponents = Nil)
+          val hocon      = ConfigFactory.parseString(emptyModel.toHocon)
+          val result     = ConfigSource.fromConfig(hocon).load[PipelineConfig]
+
+          result.isRight shouldBe true
+          result.toOption.get.pipelineComponents shouldBe empty
+        }
+      }
+    }
+  }
+
+  describe("ComponentConfig property tests") {
+
+    describe("roundtrip parsing") {
+
+      it("should parse any valid component model") {
+        forAll(genComponentModel) { model =>
+          val hocon  = ConfigFactory.parseString(model.toHocon)
+          val result = ConfigSource.fromConfig(hocon).load[ComponentConfig]
+
+          result.isRight shouldBe true
+          val config = result.toOption.get
+
+          config.instanceType shouldBe model.instanceType
+          config.instanceName shouldBe model.instanceName
+        }
+      }
+
+      it("should preserve instance-config keys") {
+        forAll(genComponentModel) { model =>
+          val hocon  = ConfigFactory.parseString(model.toHocon)
+          val result = ConfigSource.fromConfig(hocon).load[ComponentConfig]
+
+          result.isRight shouldBe true
+          val config = result.toOption.get
+
+          // Verify all keys from model are present in parsed config
+          model.instanceConfig.keys.foreach(key => config.instanceConfig.hasPath(key) shouldBe true)
+        }
+      }
+    }
+
+    describe("empty instance-config") {
+
+      it("should handle components with empty instance-config") {
+        forAll(genComponentModel) { model =>
+          val emptyConfigModel = model.copy(instanceConfig = Map.empty)
+          val hocon            = ConfigFactory.parseString(emptyConfigModel.toHocon)
+          val result           = ConfigSource.fromConfig(hocon).load[ComponentConfig]
+
+          result.isRight shouldBe true
+          result.toOption.get.instanceConfig.isEmpty shouldBe true
+        }
+      }
+    }
+  }
+
+  describe("SparkConfig property tests") {
+
+    describe("roundtrip parsing") {
+
+      it("should parse any valid spark config model") {
+        forAll(genSparkConfigModel) { model =>
+          val hocon  = ConfigFactory.parseString(model.toHocon)
+          val result = ConfigSource.fromConfig(hocon).load[SparkConfig]
+
+          result.isRight shouldBe true
+          val config = result.toOption.get
+
+          config.master shouldBe model.master
+          config.appName shouldBe model.appName
+        }
+      }
+
+      it("should preserve spark config entries") {
+        forAll(genSparkConfigModel) { model =>
+          val hocon  = ConfigFactory.parseString(model.toHocon)
+          val result = ConfigSource.fromConfig(hocon).load[SparkConfig]
+
+          result.isRight shouldBe true
+          val config = result.toOption.get
+
+          model.config.foreach {
+            case (key, value) =>
+              config.config.get(key) shouldBe Some(value)
+          }
+        }
+      }
+    }
+
+    describe("optional fields") {
+
+      it("should handle missing master") {
+        forAll(genSparkConfigModel) { model =>
+          val noMaster = model.copy(master = None)
+          val hocon    = ConfigFactory.parseString(noMaster.toHocon)
+          val result   = ConfigSource.fromConfig(hocon).load[SparkConfig]
+
+          result.isRight shouldBe true
+          result.toOption.get.master shouldBe None
+        }
+      }
+
+      it("should handle missing appName") {
+        forAll(genSparkConfigModel) { model =>
+          val noAppName = model.copy(appName = None)
+          val hocon     = ConfigFactory.parseString(noAppName.toHocon)
+          val result    = ConfigSource.fromConfig(hocon).load[SparkConfig]
+
+          result.isRight shouldBe true
+          result.toOption.get.appName shouldBe None
+        }
+      }
+
+      it("should handle empty config map") {
+        forAll(genSparkConfigModel) { model =>
+          val emptyConfig = model.copy(config = Map.empty)
+          val hocon       = ConfigFactory.parseString(emptyConfig.toHocon)
+          val result      = ConfigSource.fromConfig(hocon).load[SparkConfig]
+
+          result.isRight shouldBe true
+          result.toOption.get.config shouldBe empty
+        }
+      }
+    }
+  }
+
+  describe("negative property tests") {
+
+    describe("missing required fields") {
+
+      it("should reject PipelineConfig without pipeline-name") {
+        forAll(genPipelineModel) { _ =>
+          val hoconWithoutName =
+            s"""{
+               |  pipeline-components = []
+               |}""".stripMargin
+
+          val hocon  = ConfigFactory.parseString(hoconWithoutName)
+          val result = ConfigSource.fromConfig(hocon).load[PipelineConfig]
+
+          result.isLeft shouldBe true
+        }
+      }
+
+      it("should reject PipelineConfig without pipeline-components") {
+        forAll(genPipelineModel) { model =>
+          val hoconWithoutComponents =
+            s"""{
+               |  pipeline-name = "${model.pipelineName}"
+               |}""".stripMargin
+
+          val hocon  = ConfigFactory.parseString(hoconWithoutComponents)
+          val result = ConfigSource.fromConfig(hocon).load[PipelineConfig]
+
+          result.isLeft shouldBe true
+        }
+      }
+
+      it("should reject ComponentConfig without instance-type") {
+        forAll(genComponentModel) { model =>
+          val hoconWithoutType =
+            s"""{
+               |  instance-name = "${model.instanceName}"
+               |  instance-config {}
+               |}""".stripMargin
+
+          val hocon  = ConfigFactory.parseString(hoconWithoutType)
+          val result = ConfigSource.fromConfig(hocon).load[ComponentConfig]
+
+          result.isLeft shouldBe true
+        }
+      }
+
+      it("should reject ComponentConfig without instance-name") {
+        forAll(genComponentModel) { model =>
+          val hoconWithoutName =
+            s"""{
+               |  instance-type = "${model.instanceType}"
+               |  instance-config {}
+               |}""".stripMargin
+
+          val hocon  = ConfigFactory.parseString(hoconWithoutName)
+          val result = ConfigSource.fromConfig(hocon).load[ComponentConfig]
+
+          result.isLeft shouldBe true
+        }
+      }
+
+      it("should reject ComponentConfig without instance-config") {
+        forAll(genComponentModel) { model =>
+          val hoconWithoutConfig =
+            s"""{
+               |  instance-type = "${model.instanceType}"
+               |  instance-name = "${model.instanceName}"
+               |}""".stripMargin
+
+          val hocon  = ConfigFactory.parseString(hoconWithoutConfig)
+          val result = ConfigSource.fromConfig(hocon).load[ComponentConfig]
+
+          result.isLeft shouldBe true
+        }
+      }
+    }
+  }
+
+  describe("scalability property tests") {
+
+    it("should handle pipelines with many components") {
+      // Generate pipelines with 10-20 components
+      val genLargePipeline = for {
+        pipelineName   <- genName
+        componentCount <- Gen.choose(10, 20)
+        components     <- Gen.listOfN(componentCount, genComponentModel)
+        failFast       <- Gen.oneOf(true, false)
+      } yield PipelineModel(pipelineName, components, failFast)
+
+      forAll(genLargePipeline) { model =>
+        val hocon  = ConfigFactory.parseString(model.toHocon)
+        val result = ConfigSource.fromConfig(hocon).load[PipelineConfig]
+
+        result.isRight shouldBe true
+        result.toOption.get.pipelineComponents should have size model.pipelineComponents.size
+      }
+    }
+
+    it("should handle components with many config entries") {
+      // Generate components with 10-20 config entries
+      val genLargeConfigEntries: Gen[Map[String, ConfigValue]] = for {
+        size   <- Gen.choose(10, 20)
+        keys   <- Gen.listOfN(size, Gen.alphaLowerStr.suchThat(_.nonEmpty).map(_.take(15)))
+        values <- Gen.listOfN(size, genConfigValue)
+      } yield keys.zip(values).toMap
+
+      val genLargeComponent = for {
+        instanceType   <- genClassName
+        instanceName   <- genName
+        instanceConfig <- genLargeConfigEntries
+      } yield ComponentModel(instanceType, instanceName, instanceConfig)
+
+      forAll(genLargeComponent) { model =>
+        val hocon  = ConfigFactory.parseString(model.toHocon)
+        val result = ConfigSource.fromConfig(hocon).load[ComponentConfig]
+
+        result.isRight shouldBe true
+        model.instanceConfig.keys.foreach(key => result.toOption.get.instanceConfig.hasPath(key) shouldBe true)
+      }
+    }
+  }
+}

--- a/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/config/PropertyTestGenerators.scala
+++ b/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/config/PropertyTestGenerators.scala
@@ -1,0 +1,221 @@
+package io.github.dwsmith1983.spark.pipeline.config
+
+import org.scalacheck.{Arbitrary, Gen}
+
+/**
+ * ScalaCheck generators for property-based testing of config models.
+ *
+ * These generators produce valid configuration data that can be serialized
+ * to HOCON and parsed back, enabling roundtrip property testing.
+ *
+ * @note We generate "model" representations rather than the actual case classes
+ *       because `ComponentConfig.instanceConfig` is a typesafe `Config` object
+ *       which is not easily constructed programmatically. Instead, we generate
+ *       HOCON strings and verify parsing.
+ */
+object PropertyTestGenerators {
+
+  // ============================================================================
+  // Primitive Generators
+  // ============================================================================
+
+  /**
+   * Generates valid identifiers (alphanumeric, starts with letter).
+   * Used for class names, variable names, etc.
+   */
+  val genIdentifier: Gen[String] = for {
+    first <- Gen.alphaChar
+    rest  <- Gen.listOfN(Gen.choose(3, 20).sample.getOrElse(10), Gen.alphaNumChar)
+  } yield (first :: rest).mkString
+
+  /**
+   * Generates valid pipeline/component names.
+   * Allows spaces, hyphens, and common punctuation.
+   */
+  val genName: Gen[String] = for {
+    words <- Gen.listOfN(Gen.choose(1, 4).sample.getOrElse(2), genIdentifier)
+  } yield words.mkString(" ")
+
+  /**
+   * Generates fully qualified class names.
+   * Format: com.example.package.ClassName
+   */
+  val genClassName: Gen[String] = for {
+    packages  <- Gen.listOfN(Gen.choose(2, 4).sample.getOrElse(3), genIdentifier.map(_.toLowerCase))
+    className <- genIdentifier.map(s => s"${s.head.toUpper}${s.tail}")
+  } yield (packages :+ className).mkString(".")
+
+  /** Generates Spark master URLs. */
+  val genMaster: Gen[String] = Gen.oneOf(
+    Gen.const("local[*]"),
+    Gen.const("local[2]"),
+    Gen.const("local[4]"),
+    Gen.const("yarn"),
+    Gen.const("yarn-client"),
+    Gen.const("yarn-cluster"),
+    Gen.choose(1, 10).map(n => s"local[$n]"),
+    genIdentifier.map(h => s"spark://$h:7077")
+  )
+
+  // ============================================================================
+  // Instance Config Generators (key-value pairs for component configs)
+  // ============================================================================
+
+  /**
+   * Represents a key-value pair in instance-config.
+   * Supports string, int, boolean, and nested configs.
+   */
+  sealed trait ConfigValue {
+    def toHocon: String
+  }
+
+  case class StringValue(value: String) extends ConfigValue {
+    def toHocon: String = s""""${escapeString(value)}""""
+  }
+
+  case class IntValue(value: Int) extends ConfigValue {
+    def toHocon: String = value.toString
+  }
+
+  case class BoolValue(value: Boolean) extends ConfigValue {
+    def toHocon: String = value.toString
+  }
+
+  case class ListValue(values: List[ConfigValue]) extends ConfigValue {
+    def toHocon: String = values.map(_.toHocon).mkString("[", ", ", "]")
+  }
+
+  case class NestedValue(entries: Map[String, ConfigValue]) extends ConfigValue {
+
+    def toHocon: String =
+      if (entries.isEmpty) "{}"
+      else entries.map { case (k, v) => s""""$k" = ${v.toHocon}""" }.mkString("{ ", ", ", " }")
+  }
+
+  private def escapeString(s: String): String =
+    s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
+
+  val genConfigValue: Gen[ConfigValue] = Gen.frequency(
+    (5, Gen.alphaNumStr.map(StringValue)),
+    (3, Gen.choose(-1000, 1000).map(IntValue)),
+    (2, Gen.oneOf(true, false).map(BoolValue))
+  )
+
+  val genInstanceConfigEntries: Gen[Map[String, ConfigValue]] = for {
+    size   <- Gen.choose(0, 5)
+    keys   <- Gen.listOfN(size, Gen.alphaLowerStr.suchThat(_.nonEmpty).map(_.take(15)))
+    values <- Gen.listOfN(size, genConfigValue)
+  } yield keys.zip(values).toMap
+
+  // ============================================================================
+  // Component Model (for generation, not the actual case class)
+  // ============================================================================
+
+  /**
+   * Model representation of ComponentConfig for property testing.
+   * Can be converted to HOCON for parsing tests.
+   */
+  case class ComponentModel(
+    instanceType: String,
+    instanceName: String,
+    instanceConfig: Map[String, ConfigValue]) {
+
+    def toHocon: String =
+      s"""{
+         |  instance-type = "$instanceType"
+         |  instance-name = "$instanceName"
+         |  instance-config ${NestedValue(instanceConfig).toHocon}
+         |}""".stripMargin
+  }
+
+  val genComponentModel: Gen[ComponentModel] = for {
+    instanceType   <- genClassName
+    instanceName   <- genName
+    instanceConfig <- genInstanceConfigEntries
+  } yield ComponentModel(instanceType, instanceName, instanceConfig)
+
+  // ============================================================================
+  // Pipeline Model (for generation, not the actual case class)
+  // ============================================================================
+
+  /**
+   * Model representation of PipelineConfig for property testing.
+   * Can be converted to HOCON for parsing tests.
+   */
+  case class PipelineModel(
+    pipelineName: String,
+    pipelineComponents: List[ComponentModel],
+    failFast: Boolean) {
+
+    def toHocon: String = {
+      val componentsHocon = pipelineComponents.map(_.toHocon).mkString(",\n")
+      s"""{
+         |  pipeline-name = "$pipelineName"
+         |  fail-fast = $failFast
+         |  pipeline-components = [
+         |    $componentsHocon
+         |  ]
+         |}""".stripMargin
+    }
+  }
+
+  val genPipelineModel: Gen[PipelineModel] = for {
+    pipelineName   <- genName
+    componentCount <- Gen.choose(0, 5)
+    components     <- Gen.listOfN(componentCount, genComponentModel)
+    failFast       <- Gen.oneOf(true, false)
+  } yield PipelineModel(pipelineName, components, failFast)
+
+  /** Generator for non-empty pipeline (at least one component). */
+  val genNonEmptyPipelineModel: Gen[PipelineModel] = for {
+    pipelineName   <- genName
+    componentCount <- Gen.choose(1, 5)
+    components     <- Gen.listOfN(componentCount, genComponentModel)
+    failFast       <- Gen.oneOf(true, false)
+  } yield PipelineModel(pipelineName, components, failFast)
+
+  // ============================================================================
+  // SparkConfig Model
+  // ============================================================================
+
+  /** Model representation of SparkConfig for property testing. */
+  case class SparkConfigModel(
+    master: Option[String],
+    appName: Option[String],
+    config: Map[String, String]) {
+
+    def toHocon: String = {
+      val masterLine    = master.map(m => s"""master = "$m"""").getOrElse("")
+      val appNameLine   = appName.map(n => s"""app-name = "$n"""").getOrElse("")
+      val configEntries = config.map { case (k, v) => s""""$k" = "$v"""" }.mkString(", ")
+      val configLine    = s"config { $configEntries }"
+
+      Seq(masterLine, appNameLine, configLine).filter(_.nonEmpty).mkString("{\n  ", "\n  ", "\n}")
+    }
+  }
+
+  val genSparkConfigModel: Gen[SparkConfigModel] = for {
+    master     <- Gen.option(genMaster)
+    appName    <- Gen.option(genName)
+    configSize <- Gen.choose(0, 5)
+    configKeys <- Gen.listOfN(
+                    configSize,
+                    Gen.oneOf(
+                      "spark.executor.memory",
+                      "spark.executor.cores",
+                      "spark.driver.memory",
+                      "spark.sql.shuffle.partitions",
+                      "spark.dynamicAllocation.enabled"
+                    )
+                  )
+    configValues <- Gen.listOfN(configSize, Gen.oneOf("2g", "4g", "2", "4", "100", "200", "true", "false"))
+  } yield SparkConfigModel(master, appName, configKeys.zip(configValues).toMap)
+
+  // ============================================================================
+  // Arbitrary Instances (for ScalaTest integration)
+  // ============================================================================
+
+  implicit val arbPipelineModel: Arbitrary[PipelineModel]       = Arbitrary(genPipelineModel)
+  implicit val arbComponentModel: Arbitrary[ComponentModel]     = Arbitrary(genComponentModel)
+  implicit val arbSparkConfigModel: Arbitrary[SparkConfigModel] = Arbitrary(genSparkConfigModel)
+}


### PR DESCRIPTION
## Summary

- Add ScalaCheck property-based testing for config model parsing (21 tests, 100 iterations each)
- PropertyTestGenerators: Generators for PipelineConfig, ComponentConfig, SparkConfig
- ConfigParsingPropertySpec: Tests roundtrip parsing, component order, failFast, optional fields, missing required fields, scalability
- Fix scalastyle warnings: refactor ComponentInstantiator, break long lines in LoggingHooks and DryRunResult