### PR TITLE
chore: configure OWASP suppression file using nMoncho plugin API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,14 +54,11 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       # Cache NVD database to avoid 20+ minute downloads on each run
-      # Default location: ./data in working directory (OWASP default)
       - name: Cache OWASP NVD Database
         uses: actions/cache@v4
         with:
-          path: |
-            ./data
-            ~/.dependency-check
-          key: owasp-nvd-${{ hashFiles('build.sbt') }}
+          path: .owasp-data
+          key: owasp-nvd-v1
           restore-keys: |
             owasp-nvd-
 

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ website/build/
 website/.docusaurus/
 website/.cache-loader/
 website/static/api/
+.owasp-data/

--- a/build.sbt
+++ b/build.sbt
@@ -73,6 +73,8 @@ ThisBuild / dependencyCheckSuppressions := {
     )
   )
 }
+// Store NVD database in a cacheable location (used by CI caching)
+ThisBuild / dependencyCheckDataDirectory := Some((ThisBuild / baseDirectory).value / ".owasp-data")
 
 // Code coverage settings
 ThisBuild / coverageMinimumStmtTotal := 75


### PR DESCRIPTION
## Summary
- Fix OWASP suppression file not loading in CI by using the nMoncho plugin's native `dependencyCheckSuppressions` setting
- Remove `-DsuppressionFiles` system property which wasn't being picked up by the OWASP engine
- Use `dependencyCheckAggregate` for unified multi-module reporting
- Fix report artifact upload path to match aggregate task output location

Closes #37