### PR TITLE
chore: remove release-as override after 1.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "release-as": "1.0.0",
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
## Summary
Remove one-time `release-as: 1.0.0` override from release-please config.

Future releases follow standard semver:
- Breaking change → major (1.0.0 → 2.0.0)
- Feature → minor (1.0.0 → 1.1.0)
- Fix → patch (1.0.0 → 1.0.1)