### PR TITLE
docs: add roadmap section and skip CI tests for docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,25 @@ on:
     branches: [main]
 
 jobs:
+  # Detect what changed to skip tests for docs-only PRs
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**/*.scala'
+              - '**/*.sbt'
+              - 'project/**'
+              - 'build.sbt'
+              - '.github/workflows/**'
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -39,8 +58,9 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
-    # Skip for release-please PRs (version bump only, code already passed CI on main)
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
+    needs: changes
+    # Skip for release-please PRs and docs-only changes
+    if: ${{ !startsWith(github.head_ref, 'release-please') && needs.changes.outputs.code == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -101,9 +121,9 @@ jobs:
   test-spark3:
     name: Test (Spark 3 / Scala 2.12)
     runs-on: ubuntu-latest
-    needs: lint
-    # Skip for release-please PRs (version bump only, code already passed CI on main)
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
+    needs: [lint, changes]
+    # Skip for release-please PRs and docs-only changes
+    if: ${{ !startsWith(github.head_ref, 'release-please') && needs.changes.outputs.code == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -127,9 +147,9 @@ jobs:
   test-spark3-scala213:
     name: Test (Spark 3 / Scala 2.13)
     runs-on: ubuntu-latest
-    needs: lint
-    # Skip for release-please PRs (version bump only, code already passed CI on main)
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
+    needs: [lint, changes]
+    # Skip for release-please PRs and docs-only changes
+    if: ${{ !startsWith(github.head_ref, 'release-please') && needs.changes.outputs.code == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -153,9 +173,9 @@ jobs:
   test-spark4:
     name: Test (Spark 4 / Scala 2.13)
     runs-on: ubuntu-latest
-    needs: lint
-    # Skip for release-please PRs (version bump only, code already passed CI on main)
-    if: ${{ !startsWith(github.head_ref, 'release-please') }}
+    needs: [lint, changes]
+    # Skip for release-please PRs and docs-only changes
+    if: ${{ !startsWith(github.head_ref, 'release-please') && needs.changes.outputs.code == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -353,6 +353,18 @@ sbt scalafixAll
 sbt dependencyCheck
 ```
 
+## Roadmap
+
+Track progress on [GitHub Milestones](https://github.com/dwsmith1983/spark-pipeline-framework/milestones).
+
+| Version | Focus | Key Features |
+|---------|-------|--------------|
+| **v1.1.0** | Operational Improvements | Schema contracts ([#49](https://github.com/dwsmith1983/spark-pipeline-framework/issues/49)), Configuration validation ([#54](https://github.com/dwsmith1983/spark-pipeline-framework/issues/54)) |
+| **v1.2.0** | Resilience | Checkpointing ([#50](https://github.com/dwsmith1983/spark-pipeline-framework/issues/50)), Retry logic ([#55](https://github.com/dwsmith1983/spark-pipeline-framework/issues/55)), Data quality hooks ([#56](https://github.com/dwsmith1983/spark-pipeline-framework/issues/56)) |
+| **v2.0.0** | Parallelism | DAG-based component execution ([#51](https://github.com/dwsmith1983/spark-pipeline-framework/issues/51)) |
+| **v2.1.0** | Streaming | Structured Streaming support ([#52](https://github.com/dwsmith1983/spark-pipeline-framework/issues/52)) |
+| **v2.2.0** | Cloud Native | Secrets management ([#57](https://github.com/dwsmith1983/spark-pipeline-framework/issues/57)), Spark Connect ([#58](https://github.com/dwsmith1983/spark-pipeline-framework/issues/58)) |
+
 ## License
 
 Apache 2.0


### PR DESCRIPTION
## Summary
- Add roadmap table to README linking to GitHub milestones and issues (v1.1.0 through v2.2.0)
- Add path filtering to CI workflow using `dorny/paths-filter` to skip tests/security scan for docs-only PRs
- Lint still runs on all PRs (fast, catches formatting issues)