### PR TITLE
chore: add CODEOWNERS for auto-reviewer assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Default owner for everything
+* @dwsmith1983
+
+# CI/CD workflows
+/.github/ @dwsmith1983
+
+# Core library code
+/core/ @dwsmith1983
+/runtime/ @dwsmith1983
+/runner/ @dwsmith1983
+/example/ @dwsmith1983
+
+# Documentation
+/website/ @dwsmith1983


### PR DESCRIPTION
## Description
Add CODEOWNERS file to automatically assign reviewer on all PRs, including Dependabot PRs.

## Type of Change
- [x] `chore`: Maintenance (deps, CI, etc.)

## Related Issues

## Checklist
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Tests added/updated for changes
- [x] `sbt scalafmtCheckAll` passes
- [x] `sbt test` passes
- [x] Documentation updated (if applicable)