### PR TITLE
fix: use pathname:// protocol for ScalaDoc links

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -62,10 +62,9 @@ const config: Config = {
           label: 'Docs',
         },
         {
-          href: '/spark-pipeline-framework/api/index.html',
+          href: 'pathname:///spark-pipeline-framework/api/index.html',
           label: 'API',
           position: 'left',
-          target: '_self',
         },
         {
           href: 'https://github.com/dwsmith1983/spark-pipeline-framework',
@@ -95,8 +94,7 @@ const config: Config = {
             },
             {
               label: 'API Reference',
-              href: '/spark-pipeline-framework/api/index.html',
-              target: '_self',
+              href: 'pathname:///spark-pipeline-framework/api/index.html',
             },
           ],
         },


### PR DESCRIPTION
## Description
Fix ScalaDoc pages requiring a refresh to load correctly by using the `pathname://` protocol for API links.

The `pathname://` protocol escapes Docusaurus SPA routing, forcing a real HTTP request instead of client-side route interception.

Fixes #29

## Type of Change
- [x] `fix`: Bug fix

## Related Issues
Fixes #29

## Checklist
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Tests added/updated for changes
- [x] `sbt scalafmtCheckAll` passes
- [x] `sbt test` passes
- [x] Documentation updated (if applicable)