### PR TITLE
chore: exclude website from release-please triggers

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,9 @@
           "path": "build.sbt",
           "glob": false
         }
+      ],
+      "exclude-paths": [
+        "website"
       ]
     }
   }


### PR DESCRIPTION
## Description
Configure release-please to ignore commits that only touch the `website/` directory.

This prevents doc site changes from bumping the library version unnecessarily.

## Type of Change
- [x] `chore`: Maintenance (deps, CI, etc.)

## Related Issues

## Checklist
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Tests added/updated for changes
- [x] `sbt scalafmtCheckAll` passes
- [x] `sbt test` passes
- [x] Documentation updated (if applicable)