### PR TITLE
feat: add configuration validation tooling

### DIFF
--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/ConfigValidator.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/ConfigValidator.scala
@@ -1,0 +1,317 @@
+package io.github.dwsmith1983.spark.pipeline.config
+
+import com.typesafe.config.{Config, ConfigException, ConfigFactory}
+import pureconfig.ConfigSource
+import pureconfig.generic.auto._
+
+import scala.language.existentials
+import scala.util.{Failure, Success, Try}
+
+/**
+ * Validates pipeline configuration without instantiating components.
+ *
+ * This provides faster validation than [[DryRunResult dry-run]] by checking
+ * configuration structure and class availability without calling
+ * `createFromConfig`. Use this for pre-flight checks in CI/CD pipelines.
+ *
+ * == Validation Phases ==
+ *
+ *   1. '''ConfigSyntax''': HOCON syntax correctness
+ *   1. '''RequiredFields''': pipelineName and pipelineComponents present
+ *   1. '''TypeResolution''': Classes and companion objects exist
+ *   1. '''ComponentConfig''': Companion objects extend ConfigurableInstance
+ *   1. '''ResourceValidation''': (Optional) Referenced paths/tables exist
+ *
+ * == Example ==
+ *
+ * {{{
+ * val result = ConfigValidator.validate(config)
+ * if (result.isInvalid) {
+ *   result.errors.foreach(e => println(e.fullMessage))
+ * }
+ * }}}
+ */
+object ConfigValidator {
+
+  /**
+   * Validates a configuration.
+   *
+   * @param config The HOCON configuration to validate
+   * @return ValidationResult with all errors and warnings
+   */
+  def validate(config: Config): ValidationResult =
+    validate(config, ValidationOptions.Default)
+
+  /**
+   * Validates a configuration with options.
+   *
+   * @param config  The HOCON configuration to validate
+   * @param options Validation options (e.g., resource checking)
+   * @return ValidationResult with all errors and warnings
+   */
+  def validate(config: Config, options: ValidationOptions): ValidationResult = {
+    val errors   = List.newBuilder[ValidationError]
+    val warnings = List.newBuilder[ValidationWarning]
+
+    // Phase 2: Required fields
+    val pipelineConfigResult = validateRequiredFields(config, errors)
+
+    pipelineConfigResult match {
+      case None =>
+        ValidationResult.Invalid(errors.result(), warnings.result())
+
+      case Some(pipelineConfig) =>
+        pipelineConfig.pipelineComponents.zipWithIndex.foreach {
+          case (componentConfig, idx) =>
+            validateComponent(componentConfig, idx, errors)
+        }
+
+        if (options.validateResources) {
+          validateResources(pipelineConfig, options, errors, warnings)
+        }
+
+        val errorList = errors.result()
+        if (errorList.isEmpty) {
+          ValidationResult.Valid(
+            pipelineConfig.pipelineName,
+            pipelineConfig.pipelineComponents.size,
+            warnings.result()
+          )
+        } else {
+          ValidationResult.Invalid(errorList, warnings.result())
+        }
+    }
+  }
+
+  /**
+   * Validates a configuration from a HOCON string.
+   *
+   * @param hoconString The HOCON configuration string
+   * @return ValidationResult with all errors and warnings
+   */
+  def validateFromString(hoconString: String): ValidationResult =
+    validateFromString(hoconString, ValidationOptions.Default)
+
+  /**
+   * Validates a configuration from a HOCON string with options.
+   *
+   * @param hoconString The HOCON configuration string
+   * @param options     Validation options
+   * @return ValidationResult with all errors and warnings
+   */
+  def validateFromString(hoconString: String, options: ValidationOptions): ValidationResult =
+    Try(ConfigFactory.parseString(hoconString)) match {
+      case Success(config) => validate(config, options)
+      case Failure(e: ConfigException) =>
+        ValidationResult.invalid(
+          ValidationError(
+            ValidationPhase.ConfigSyntax,
+            ErrorLocation.Pipeline,
+            s"Failed to parse HOCON: ${e.getMessage}",
+            Some(e)
+          )
+        )
+      case Failure(e) =>
+        ValidationResult.invalid(
+          ValidationError(
+            ValidationPhase.ConfigSyntax,
+            ErrorLocation.Pipeline,
+            s"Unexpected error parsing configuration: ${e.getMessage}",
+            Some(e)
+          )
+        )
+    }
+
+  /**
+   * Validates a configuration from a file path.
+   *
+   * @param configPath Path to the HOCON configuration file
+   * @return ValidationResult with all errors and warnings
+   */
+  def validateFromFile(configPath: String): ValidationResult =
+    validateFromFile(configPath, ValidationOptions.Default)
+
+  /**
+   * Validates a configuration from a file path with options.
+   *
+   * @param configPath Path to the HOCON configuration file
+   * @param options    Validation options
+   * @return ValidationResult with all errors and warnings
+   */
+  def validateFromFile(configPath: String, options: ValidationOptions): ValidationResult = {
+    val file = new java.io.File(configPath)
+    if (!file.exists()) {
+      ValidationResult.invalid(
+        ValidationError(
+          ValidationPhase.ConfigSyntax,
+          ErrorLocation.Pipeline,
+          s"Configuration file not found: $configPath"
+        )
+      )
+    } else {
+      Try(ConfigFactory.parseFile(file)) match {
+        case Success(config) => validate(config, options)
+        case Failure(e: ConfigException) =>
+          ValidationResult.invalid(
+            ValidationError(
+              ValidationPhase.ConfigSyntax,
+              ErrorLocation.Pipeline,
+              s"Failed to parse configuration file: ${e.getMessage}",
+              Some(e)
+            )
+          )
+        case Failure(e) =>
+          ValidationResult.invalid(
+            ValidationError(
+              ValidationPhase.ConfigSyntax,
+              ErrorLocation.Pipeline,
+              s"Unexpected error reading configuration file: ${e.getMessage}",
+              Some(e)
+            )
+          )
+      }
+    }
+  }
+
+  private def validateRequiredFields(
+    config: Config,
+    errors: scala.collection.mutable.Builder[ValidationError, List[ValidationError]]
+  ): Option[PipelineConfig] =
+    if (!config.hasPath("pipeline")) {
+      errors += ValidationError(
+        ValidationPhase.RequiredFields,
+        ErrorLocation.Pipeline,
+        "Missing required 'pipeline' block in configuration"
+      )
+      None
+    } else {
+      Try(ConfigSource.fromConfig(config.getConfig("pipeline")).loadOrThrow[PipelineConfig]) match {
+        case Success(pipelineConfig) =>
+          if (pipelineConfig.pipelineComponents.isEmpty) {
+            errors += ValidationError(
+              ValidationPhase.RequiredFields,
+              ErrorLocation.Pipeline,
+              "Pipeline must have at least one component in 'pipeline-components'"
+            )
+          }
+          Some(pipelineConfig)
+
+        case Failure(e: pureconfig.error.ConfigReaderException[_]) =>
+          errors += ValidationError(
+            ValidationPhase.RequiredFields,
+            ErrorLocation.Pipeline,
+            s"Invalid pipeline configuration: ${e.failures.toList.map(_.description).mkString("; ")}",
+            Some(e)
+          )
+          None
+
+        case Failure(e) =>
+          errors += ValidationError(
+            ValidationPhase.RequiredFields,
+            ErrorLocation.Pipeline,
+            s"Failed to parse pipeline configuration: ${e.getMessage}",
+            Some(e)
+          )
+          None
+      }
+    }
+
+  private def validateComponent(
+    componentConfig: ComponentConfig,
+    index: Int,
+    errors: scala.collection.mutable.Builder[ValidationError, List[ValidationError]]
+  ): Unit = {
+    val location = ErrorLocation.Component(
+      index,
+      componentConfig.instanceType,
+      componentConfig.instanceName
+    )
+    val className = componentConfig.instanceType
+
+    // Phase 3: Type resolution - verify class exists
+    val classLoadResult = Try(Class.forName(className))
+
+    classLoadResult match {
+      case Failure(_: ClassNotFoundException) =>
+        errors += ValidationError(
+          ValidationPhase.TypeResolution,
+          location,
+          s"Class not found: $className. Ensure the class is on the classpath."
+        )
+
+      case Failure(e) =>
+        errors += ValidationError(
+          ValidationPhase.TypeResolution,
+          location,
+          s"Error loading class $className: ${e.getMessage}",
+          Some(e)
+        )
+
+      case Success(_) =>
+        // Class exists, now verify companion object
+        validateCompanionObject(className, location, errors)
+    }
+  }
+
+  private def validateCompanionObject(
+    className: String,
+    location: ErrorLocation,
+    errors: scala.collection.mutable.Builder[ValidationError, List[ValidationError]]
+  ): Unit = {
+    val companionClassResult = Try(Class.forName(className + "$"))
+
+    companionClassResult match {
+      case Failure(_: ClassNotFoundException) =>
+        errors += ValidationError(
+          ValidationPhase.TypeResolution,
+          location,
+          s"Companion object not found for $className. " +
+            "Ensure it has a companion object extending ConfigurableInstance."
+        )
+
+      case Failure(e) =>
+        errors += ValidationError(
+          ValidationPhase.TypeResolution,
+          location,
+          s"Error loading companion object for $className: ${e.getMessage}",
+          Some(e)
+        )
+
+      case Success(companionClass) =>
+        val moduleResult = Try(companionClass.getField("MODULE$").get(null))
+        moduleResult match {
+          case Failure(e) =>
+            errors += ValidationError(
+              ValidationPhase.TypeResolution,
+              location,
+              s"Could not access companion object for $className: ${e.getMessage}",
+              Some(e)
+            )
+
+          case Success(companion) =>
+            // Phase 4: Verify companion extends ConfigurableInstance
+            if (!companion.isInstanceOf[ConfigurableInstance]) {
+              errors += ValidationError(
+                ValidationPhase.ComponentConfig,
+                location,
+                s"Companion object of $className does not extend ConfigurableInstance"
+              )
+            }
+        }
+    }
+  }
+
+  private def validateResources(
+    pipelineConfig: PipelineConfig,
+    options: ValidationOptions,
+    errors: scala.collection.mutable.Builder[ValidationError, List[ValidationError]],
+    warnings: scala.collection.mutable.Builder[ValidationWarning, List[ValidationWarning]]
+  ): Unit = {
+    val _ = (pipelineConfig, options, errors) // suppress unused warnings
+    warnings += ValidationWarning(
+      ErrorLocation.Pipeline,
+      "Resource validation is limited. Use dryRun for complete validation including " +
+        "component instantiation and config parsing."
+    )
+  }
+}

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/ValidationResult.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/ValidationResult.scala
@@ -1,0 +1,214 @@
+package io.github.dwsmith1983.spark.pipeline.config
+
+/**
+ * Result of pipeline configuration validation.
+ *
+ * Validation checks the configuration structure and class availability without
+ * instantiating components. This is faster than [[DryRunResult dry-run]] and has
+ * no side effects from component initialization.
+ *
+ * Use `validate` for quick pre-flight checks, and `dryRun` when you need to
+ * verify that components can be fully instantiated.
+ *
+ * == Example ==
+ *
+ * {{{
+ * val result = SimplePipelineRunner.validate(config)
+ * result match {
+ *   case ValidationResult.Valid(pipelineName, componentCount, warns) =>
+ *     warns.foreach(w => println("Warning: " + w.message))
+ *     println("Pipeline '" + pipelineName + "' is valid with " + componentCount + " components")
+ *   case ValidationResult.Invalid(errs, warns) =>
+ *     errs.foreach(e => println("Error: " + e.message))
+ *     sys.exit(1)
+ * }
+ * }}}
+ */
+sealed trait ValidationResult {
+
+  /** Whether the validation passed. */
+  def isValid: Boolean
+
+  /** Whether the validation failed. */
+  def isInvalid: Boolean = !isValid
+
+  /** All validation errors encountered. Empty for valid results. */
+  def errors: List[ValidationError]
+
+  /** Non-fatal warnings encountered during validation. */
+  def warnings: List[ValidationWarning]
+
+  /**
+   * Combine this result with another, accumulating errors and warnings.
+   *
+   * If either result is invalid, the combined result is invalid.
+   * Warnings are accumulated from both results.
+   */
+  def ++(other: ValidationResult): ValidationResult
+}
+
+object ValidationResult {
+
+  /**
+   * Indicates the pipeline configuration is valid.
+   *
+   * All validation phases passed:
+   * - Configuration syntax is correct
+   * - Required fields are present
+   * - Component classes exist and are accessible
+   * - Component companion objects extend [[ConfigurableInstance]]
+   *
+   * @param pipelineName   The name of the validated pipeline
+   * @param componentCount Number of components in the pipeline
+   * @param warnings       Non-fatal warnings encountered
+   */
+  final case class Valid(
+    pipelineName: String,
+    componentCount: Int,
+    warnings: List[ValidationWarning] = List.empty)
+    extends ValidationResult {
+
+    override def isValid: Boolean              = true
+    override def errors: List[ValidationError] = List.empty
+
+    override def ++(other: ValidationResult): ValidationResult = other match {
+      case Valid(_, _, otherWarnings) =>
+        copy(warnings = warnings ++ otherWarnings)
+      case Invalid(otherErrors, otherWarnings) =>
+        Invalid(otherErrors, warnings ++ otherWarnings)
+    }
+  }
+
+  /**
+   * Indicates the pipeline configuration is invalid.
+   *
+   * @param errors   List of validation errors encountered
+   * @param warnings Non-fatal warnings encountered
+   */
+  final case class Invalid(
+    errors: List[ValidationError],
+    warnings: List[ValidationWarning] = List.empty)
+    extends ValidationResult {
+
+    override def isValid: Boolean = false
+
+    override def ++(other: ValidationResult): ValidationResult = other match {
+      case Valid(_, _, otherWarnings) =>
+        copy(warnings = warnings ++ otherWarnings)
+      case Invalid(otherErrors, otherWarnings) =>
+        Invalid(errors ++ otherErrors, warnings ++ otherWarnings)
+    }
+  }
+
+  /** Create an invalid result from a single error. */
+  def invalid(error: ValidationError): Invalid = Invalid(List(error))
+
+  /** Create a valid result with no warnings. */
+  def valid(pipelineName: String, componentCount: Int): Valid =
+    Valid(pipelineName, componentCount)
+}
+
+/** Phase of validation where an error occurred. */
+sealed trait ValidationPhase {
+  def name: String
+}
+
+object ValidationPhase {
+
+  /** HOCON syntax validation. */
+  case object ConfigSyntax extends ValidationPhase {
+    override def name: String = "config-syntax"
+  }
+
+  /** Required fields validation (pipelineName, pipelineComponents). */
+  case object RequiredFields extends ValidationPhase {
+    override def name: String = "required-fields"
+  }
+
+  /** Class and companion object resolution. */
+  case object TypeResolution extends ValidationPhase {
+    override def name: String = "type-resolution"
+  }
+
+  /** Component configuration structure validation. */
+  case object ComponentConfig extends ValidationPhase {
+    override def name: String = "component-config"
+  }
+
+  /** Optional resource existence validation (paths, tables). */
+  case object ResourceValidation extends ValidationPhase {
+    override def name: String = "resource-validation"
+  }
+}
+
+/** Location in the configuration where an error occurred. */
+sealed trait ErrorLocation {
+  def description: String
+}
+
+object ErrorLocation {
+
+  /** Error at the pipeline level (not specific to a component). */
+  case object Pipeline extends ErrorLocation {
+    override def description: String = "pipeline configuration"
+  }
+
+  /**
+   * Error for a specific component.
+   *
+   * @param index        Zero-based index of the component in the pipeline
+   * @param instanceType Fully qualified class name
+   * @param instanceName Human-readable instance name
+   */
+  final case class Component(index: Int, instanceType: String, instanceName: String)
+    extends ErrorLocation {
+    override def description: String = s"component[$index] '$instanceName' ($instanceType)"
+  }
+}
+
+/**
+ * A validation error with phase and location context.
+ *
+ * @param phase    The validation phase where the error occurred
+ * @param location Where in the configuration the error occurred
+ * @param message  Human-readable description of the error
+ * @param cause    The underlying exception, if any
+ */
+final case class ValidationError(
+  phase: ValidationPhase,
+  location: ErrorLocation,
+  message: String,
+  cause: Option[Throwable] = None) {
+
+  /** Formatted error message including phase and location. */
+  def fullMessage: String =
+    s"[${phase.name}] ${location.description}: $message"
+}
+
+/**
+ * A non-fatal validation warning.
+ *
+ * @param location Where in the configuration the warning applies
+ * @param message  Human-readable description of the warning
+ */
+final case class ValidationWarning(location: ErrorLocation, message: String) {
+
+  /** Formatted warning message including location. */
+  def fullMessage: String = s"${location.description}: $message"
+}
+
+/**
+ * Options for controlling validation behavior.
+ *
+ * @param validateResources Whether to validate that referenced paths and tables exist.
+ *                          Defaults to false for fast validation. Note: Resource validation
+ *                          is currently limited and serves as a placeholder for future
+ *                          enhancements.
+ */
+final case class ValidationOptions(validateResources: Boolean = false)
+
+object ValidationOptions {
+
+  /** Default options: fast validation without resource checks. */
+  val Default: ValidationOptions = ValidationOptions()
+}


### PR DESCRIPTION
## Description

Add `validate()` method to SimplePipelineRunner for lightweight pre-instantiation configuration validation.

This provides faster validation than `dryRun` by checking configuration structure and class availability without calling `createFromConfig`. Useful for CI/CD pre-flight checks.

**New files:**
- `ValidationResult.scala` - Result types (Valid, Invalid, ValidationError, ValidationPhase, ErrorLocation, ValidationWarning, ValidationOptions)
- `ConfigValidator.scala` - Phased validation logic

**Validation phases:**
1. ConfigSyntax - HOCON parseability
2. RequiredFields - pipelineName, pipelineComponents present
3. TypeResolution - Class.forName and companion object exist
4. ComponentConfig - Companion extends ConfigurableInstance
5. ResourceValidation - Optional placeholder for future enhancement

## Type of Change
- [x] `feat`: New feature

## Related Issues
Closes #54

## Checklist
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Tests added/updated for changes (14 new validate tests)
- [x] `sbt scalafmtCheckAll` passes
- [x] `sbt test` passes (262 tests across all matrix combinations)
- [x] Documentation updated (ScalaDoc added to all new types and methods)