### PR TITLE
feat: add optional schema contracts between pipeline components

### DIFF
--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/ConfigModels.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/ConfigModels.scala
@@ -15,6 +15,11 @@ import com.typesafe.config.Config
  * pipeline {
  *   pipeline-name = "My Data Pipeline"
  *   fail-fast = true  # Optional, defaults to true
+ *   schema-validation {  # Optional
+ *     enabled = true
+ *     strict = false
+ *     fail-on-warning = false
+ *   }
  *   pipeline-components = [...]
  * }
  * }}}
@@ -23,11 +28,14 @@ import com.typesafe.config.Config
  * @param pipelineComponents List of components to execute in order
  * @param failFast If true (default), stop on first component failure.
  *                 If false, continue executing remaining components and report all failures.
+ * @param schemaValidation Optional schema validation configuration. When enabled,
+ *                         the runner validates schema contracts between adjacent components.
  */
 case class PipelineConfig(
   pipelineName: String,
   pipelineComponents: List[ComponentConfig],
-  failFast: Boolean = true)
+  failFast: Boolean = true,
+  schemaValidation: Option[SchemaValidationConfig] = None)
 
 /**
  * Configuration for a single pipeline component.

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/SchemaContract.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/SchemaContract.scala
@@ -1,0 +1,495 @@
+package io.github.dwsmith1983.spark.pipeline.config
+
+/**
+ * Schema contracts for pipeline components.
+ *
+ * Components can optionally declare their input and output schemas to enable
+ * runtime validation between adjacent components in a pipeline. This helps
+ * catch schema mismatches early with clear error messages, rather than
+ * failing deep in component execution with unclear errors.
+ *
+ * == Overview ==
+ *
+ * Schema contracts are entirely optional and backward compatible:
+ *
+ *   - Components without contracts continue to work unchanged
+ *   - Validation only occurs when both producer and consumer declare contracts
+ *   - Schema validation is disabled by default in pipeline config
+ *
+ * == Usage ==
+ *
+ * {{{
+ * class MyTransform(conf: MyTransform.Config) extends DataFlow with SchemaContract {
+ *   import spark.implicits._
+ *
+ *   override def inputContract: Option[SchemaDefinition] = Some(
+ *     SchemaDefinition(Seq(
+ *       SchemaField("user_id", "string", nullable = false),
+ *       SchemaField("amount", "double")
+ *     ))
+ *   )
+ *
+ *   override def outputContract: Option[SchemaDefinition] = Some(
+ *     SchemaDefinition(Seq(
+ *       SchemaField("user_id", "string", nullable = false),
+ *       SchemaField("amount", "double"),
+ *       SchemaField("processed_at", "timestamp")
+ *     ))
+ *   )
+ *
+ *   override def run(): Unit = {
+ *     // Implementation
+ *   }
+ * }
+ * }}}
+ *
+ * == Configuration ==
+ *
+ * Enable schema validation in pipeline config:
+ *
+ * {{{
+ * pipeline {
+ *   pipeline-name = "My Pipeline"
+ *   schema-validation {
+ *     enabled = true
+ *     strict = false        // If true, all components must have contracts
+ *     fail-on-warning = false  // If true, warnings become errors
+ *   }
+ *   pipeline-components = [...]
+ * }
+ * }}}
+ */
+trait SchemaContract {
+
+  /**
+   * Optional schema that this component expects from its input data.
+   *
+   * When declared, the pipeline runner validates that the previous component's
+   * output contract (if any) is compatible with this input contract.
+   *
+   * @return The expected input schema, or None if not declared
+   */
+  def inputContract: Option[SchemaDefinition] = None
+
+  /**
+   * Optional schema that this component produces as output.
+   *
+   * When declared, the pipeline runner validates that this output contract
+   * is compatible with the next component's input contract (if any).
+   *
+   * @return The produced output schema, or None if not declared
+   */
+  def outputContract: Option[SchemaDefinition] = None
+}
+
+/**
+ * A platform-independent schema definition.
+ *
+ * This class provides a lightweight representation of DataFrame schemas that
+ * does not depend on Spark. It can be converted to/from Spark's StructType
+ * in the runtime module.
+ *
+ * @param fields      The fields in this schema
+ * @param description Optional human-readable description of the schema
+ */
+final case class SchemaDefinition(
+  fields: Seq[SchemaField],
+  description: Option[String] = None) {
+
+  /** Field names in this schema. */
+  def fieldNames: Seq[String] = fields.map(_.name)
+
+  /** Get a field by name, if it exists. */
+  def field(name: String): Option[SchemaField] = fields.find(_.name == name)
+
+  /** Check if this schema contains a field with the given name. */
+  def hasField(name: String): Boolean = fields.exists(_.name == name)
+
+  /** Number of fields in this schema. */
+  def size: Int = fields.size
+}
+
+object SchemaDefinition {
+
+  /** Create an empty schema definition. */
+  val empty: SchemaDefinition = SchemaDefinition(Seq.empty)
+
+  /**
+   * Create a schema definition from field tuples.
+   *
+   * Convenience method for simple schema declarations:
+   * {{{
+   * SchemaDefinition.of(
+   *   ("user_id", "string", false),
+   *   ("amount", "double", true)
+   * )
+   * }}}
+   */
+  def of(fields: (String, String, Boolean)*): SchemaDefinition =
+    SchemaDefinition(fields.map { case (name, dataType, nullable) =>
+      SchemaField(name, dataType, nullable)
+    })
+}
+
+/**
+ * A single field in a schema definition.
+ *
+ * @param name     The field name
+ * @param dataType The data type as a string (e.g., "string", "integer", "double",
+ *                 "boolean", "timestamp", "date", "binary", "array", "map", "struct")
+ * @param nullable Whether the field can contain null values (default: true)
+ * @param metadata Optional key-value metadata for the field
+ */
+final case class SchemaField(
+  name: String,
+  dataType: String,
+  nullable: Boolean = true,
+  metadata: Map[String, String] = Map.empty) {
+
+  /** Normalized data type (lowercase, trimmed). */
+  def normalizedDataType: String = dataType.toLowerCase.trim
+}
+
+object SchemaField {
+
+  /** Common data type constants. */
+  object DataTypes {
+    val String: String    = "string"
+    val Integer: String   = "integer"
+    val Long: String      = "long"
+    val Double: String    = "double"
+    val Float: String     = "float"
+    val Boolean: String   = "boolean"
+    val Timestamp: String = "timestamp"
+    val Date: String      = "date"
+    val Binary: String    = "binary"
+    val Decimal: String   = "decimal"
+    val Array: String     = "array"
+    val Map: String       = "map"
+    val Struct: String    = "struct"
+  }
+}
+
+/**
+ * Configuration for schema validation behavior.
+ *
+ * @param enabled       Whether schema validation is enabled (default: false)
+ * @param strict        If true, all components must declare schemas (default: false)
+ * @param failOnWarning If true, validation warnings are treated as errors (default: false)
+ */
+final case class SchemaValidationConfig(
+  enabled: Boolean = false,
+  strict: Boolean = false,
+  failOnWarning: Boolean = false)
+
+object SchemaValidationConfig {
+
+  /** Default configuration: validation disabled. */
+  val Default: SchemaValidationConfig = SchemaValidationConfig()
+
+  /** Enabled configuration with default options. */
+  val Enabled: SchemaValidationConfig = SchemaValidationConfig(enabled = true)
+
+  /** Strict configuration: enabled with all contracts required. */
+  val Strict: SchemaValidationConfig =
+    SchemaValidationConfig(enabled = true, strict = true, failOnWarning = true)
+}
+
+/**
+ * Result of schema validation between two components.
+ */
+sealed trait SchemaValidationResult {
+
+  /** Whether the validation passed without errors. */
+  def isValid: Boolean
+
+  /** Whether the validation failed. */
+  def isInvalid: Boolean = !isValid
+
+  /** All validation errors encountered. */
+  def errors: List[SchemaValidationError]
+
+  /** Non-fatal warnings encountered. */
+  def warnings: List[SchemaValidationWarning]
+}
+
+object SchemaValidationResult {
+
+  /**
+   * Schema validation passed.
+   *
+   * @param warnings Non-fatal warnings encountered
+   */
+  final case class Valid(warnings: List[SchemaValidationWarning] = List.empty)
+    extends SchemaValidationResult {
+
+    override def isValid: Boolean                         = true
+    override def errors: List[SchemaValidationError] = List.empty
+  }
+
+  /**
+   * Schema validation failed.
+   *
+   * @param errors   Validation errors that caused the failure
+   * @param warnings Non-fatal warnings also encountered
+   */
+  final case class Invalid(
+    errors: List[SchemaValidationError],
+    warnings: List[SchemaValidationWarning] = List.empty)
+    extends SchemaValidationResult {
+
+    override def isValid: Boolean = false
+  }
+
+  /** Validation skipped because contracts were not declared. */
+  case object Skipped extends SchemaValidationResult {
+    override def isValid: Boolean                           = true
+    override def errors: List[SchemaValidationError]   = List.empty
+    override def warnings: List[SchemaValidationWarning] = List.empty
+  }
+
+  /** Create an invalid result from a single error. */
+  def invalid(error: SchemaValidationError): Invalid = Invalid(List(error))
+
+  /** Create a valid result with no warnings. */
+  val valid: Valid = Valid()
+}
+
+/**
+ * A schema validation error.
+ *
+ * @param errorType   The type of schema error
+ * @param message     Human-readable description
+ * @param fieldName   The field name involved, if applicable
+ * @param expected    Expected value (type, nullability, etc.)
+ * @param actual      Actual value found
+ */
+final case class SchemaValidationError(
+  errorType: SchemaErrorType,
+  message: String,
+  fieldName: Option[String] = None,
+  expected: Option[String] = None,
+  actual: Option[String] = None) {
+
+  /** Formatted error message with all details. */
+  def fullMessage: String = {
+    val details = List(
+      fieldName.map(f => s"field: $f"),
+      expected.map(e => s"expected: $e"),
+      actual.map(a => s"actual: $a")
+    ).flatten.mkString(", ")
+    if (details.nonEmpty) s"$message ($details)" else message
+  }
+}
+
+/** Types of schema validation errors. */
+sealed trait SchemaErrorType {
+  def name: String
+}
+
+object SchemaErrorType {
+
+  /** A required field is missing from the output schema. */
+  case object MissingField extends SchemaErrorType {
+    override def name: String = "missing-field"
+  }
+
+  /** Field types are incompatible. */
+  case object TypeMismatch extends SchemaErrorType {
+    override def name: String = "type-mismatch"
+  }
+
+  /** A non-nullable field is being fed by a nullable field. */
+  case object NullabilityViolation extends SchemaErrorType {
+    override def name: String = "nullability-violation"
+  }
+
+  /** Generic schema incompatibility. */
+  case object Incompatible extends SchemaErrorType {
+    override def name: String = "incompatible"
+  }
+}
+
+/**
+ * A non-fatal schema validation warning.
+ *
+ * @param warningType The type of warning
+ * @param message     Human-readable description
+ * @param fieldName   The field name involved, if applicable
+ */
+final case class SchemaValidationWarning(
+  warningType: SchemaWarningType,
+  message: String,
+  fieldName: Option[String] = None) {
+
+  /** Formatted warning message. */
+  def fullMessage: String =
+    fieldName.map(f => s"$message (field: $f)").getOrElse(message)
+}
+
+/** Types of schema validation warnings. */
+sealed trait SchemaWarningType {
+  def name: String
+}
+
+object SchemaWarningType {
+
+  /** Only one component in a pair has a schema contract. */
+  case object PartialContract extends SchemaWarningType {
+    override def name: String = "partial-contract"
+  }
+
+  /** Output has extra fields not consumed by the next component. */
+  case object ExtraFields extends SchemaWarningType {
+    override def name: String = "extra-fields"
+  }
+
+  /** Component should have a contract in strict mode. */
+  case object MissingContract extends SchemaWarningType {
+    override def name: String = "missing-contract"
+  }
+}
+
+/**
+ * Validates schema compatibility between adjacent components.
+ */
+object SchemaValidator {
+
+  /**
+   * Validate that an output schema is compatible with an input schema.
+   *
+   * Compatibility rules:
+   *   - All fields required by input must exist in output
+   *   - Field types must be compatible (exact match for now)
+   *   - Non-nullable input fields require non-nullable output fields
+   *
+   * @param output The output schema from the producer component
+   * @param input  The input schema expected by the consumer component
+   * @return Validation result with errors and warnings
+   */
+  def validate(output: SchemaDefinition, input: SchemaDefinition): SchemaValidationResult = {
+    val errors   = scala.collection.mutable.ListBuffer.empty[SchemaValidationError]
+    val warnings = scala.collection.mutable.ListBuffer.empty[SchemaValidationWarning]
+
+    // Check that all input fields exist in output
+    input.fields.foreach { inputField =>
+      output.field(inputField.name) match {
+        case None =>
+          errors += SchemaValidationError(
+            errorType = SchemaErrorType.MissingField,
+            message = s"Required field '${inputField.name}' is missing from producer output",
+            fieldName = Some(inputField.name),
+            expected = Some(inputField.dataType)
+          )
+
+        case Some(outputField) =>
+          // Check type compatibility
+          if (outputField.normalizedDataType != inputField.normalizedDataType) {
+            errors += SchemaValidationError(
+              errorType = SchemaErrorType.TypeMismatch,
+              message = s"Field '${inputField.name}' has incompatible type",
+              fieldName = Some(inputField.name),
+              expected = Some(inputField.dataType),
+              actual = Some(outputField.dataType)
+            )
+          }
+
+          // Check nullability
+          if (!inputField.nullable && outputField.nullable) {
+            errors += SchemaValidationError(
+              errorType = SchemaErrorType.NullabilityViolation,
+              message = s"Field '${inputField.name}' is non-nullable in consumer but nullable in producer",
+              fieldName = Some(inputField.name),
+              expected = Some("non-nullable"),
+              actual = Some("nullable")
+            )
+          }
+      }
+    }
+
+    // Warn about extra fields in output not consumed by input
+    val extraFields = output.fieldNames.filterNot(input.hasField)
+    if (extraFields.nonEmpty) {
+      warnings += SchemaValidationWarning(
+        warningType = SchemaWarningType.ExtraFields,
+        message = s"Producer output has ${extraFields.size} field(s) not consumed: ${extraFields.mkString(", ")}"
+      )
+    }
+
+    if (errors.isEmpty) {
+      SchemaValidationResult.Valid(warnings.toList)
+    } else {
+      SchemaValidationResult.Invalid(errors.toList, warnings.toList)
+    }
+  }
+
+  /**
+   * Validate schema contracts between two components.
+   *
+   * @param producer The component producing output
+   * @param consumer The component consuming input
+   * @param config   Schema validation configuration
+   * @return Validation result
+   */
+  def validateComponents(
+    producer: Option[SchemaContract],
+    consumer: Option[SchemaContract],
+    config: SchemaValidationConfig
+  ): SchemaValidationResult = {
+    if (!config.enabled) {
+      return SchemaValidationResult.Skipped
+    }
+
+    val producerOutput = producer.flatMap(_.outputContract)
+    val consumerInput  = consumer.flatMap(_.inputContract)
+
+    (producerOutput, consumerInput) match {
+      case (Some(output), Some(input)) =>
+        validate(output, input)
+
+      case (None, Some(_)) if config.strict =>
+        SchemaValidationResult.Invalid(List(
+          SchemaValidationError(
+            errorType = SchemaErrorType.Incompatible,
+            message = "Producer component does not declare an output schema (strict mode)"
+          )
+        ))
+
+      case (Some(_), None) if config.strict =>
+        SchemaValidationResult.Invalid(List(
+          SchemaValidationError(
+            errorType = SchemaErrorType.Incompatible,
+            message = "Consumer component does not declare an input schema (strict mode)"
+          )
+        ))
+
+      case (None, Some(_)) =>
+        SchemaValidationResult.Valid(List(
+          SchemaValidationWarning(
+            warningType = SchemaWarningType.PartialContract,
+            message = "Producer does not declare output schema; consumer input schema cannot be validated"
+          )
+        ))
+
+      case (Some(_), None) =>
+        SchemaValidationResult.Valid(List(
+          SchemaValidationWarning(
+            warningType = SchemaWarningType.PartialContract,
+            message = "Consumer does not declare input schema; producer output schema will not be validated"
+          )
+        ))
+
+      case (None, None) =>
+        if (config.strict) {
+          SchemaValidationResult.Invalid(List(
+            SchemaValidationError(
+              errorType = SchemaErrorType.Incompatible,
+              message = "Neither component declares a schema contract (strict mode)"
+            )
+          ))
+        } else {
+          SchemaValidationResult.Skipped
+        }
+    }
+  }
+}

--- a/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/config/SchemaContractSpec.scala
+++ b/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/config/SchemaContractSpec.scala
@@ -1,0 +1,502 @@
+package io.github.dwsmith1983.spark.pipeline.config
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import pureconfig._
+import pureconfig.generic.auto._
+
+/**
+ * Tests for schema contract functionality.
+ */
+class SchemaContractSpec extends AnyFunSpec with Matchers {
+
+  describe("SchemaField") {
+
+    describe("construction") {
+
+      it("should create a field with defaults") {
+        val field = SchemaField("id", "string")
+
+        field.name shouldBe "id"
+        field.dataType shouldBe "string"
+        field.nullable shouldBe true
+        field.metadata shouldBe empty
+      }
+
+      it("should create a non-nullable field") {
+        val field = SchemaField("id", "integer", nullable = false)
+
+        field.nullable shouldBe false
+      }
+
+      it("should include metadata") {
+        val field = SchemaField("amount", "decimal", metadata = Map("precision" -> "10", "scale" -> "2"))
+
+        field.metadata should contain("precision" -> "10")
+        field.metadata should contain("scale" -> "2")
+      }
+    }
+
+    describe("normalizedDataType") {
+
+      it("should lowercase the data type") {
+        SchemaField("f", "STRING").normalizedDataType shouldBe "string"
+        SchemaField("f", "INTEGER").normalizedDataType shouldBe "integer"
+        SchemaField("f", "TimestamP").normalizedDataType shouldBe "timestamp"
+      }
+
+      it("should trim whitespace") {
+        SchemaField("f", "  string  ").normalizedDataType shouldBe "string"
+      }
+    }
+  }
+
+  describe("SchemaDefinition") {
+
+    describe("construction") {
+
+      it("should create an empty schema") {
+        val schema = SchemaDefinition.empty
+
+        schema.fields shouldBe empty
+        schema.description shouldBe None
+      }
+
+      it("should create a schema from fields") {
+        val schema = SchemaDefinition(Seq(
+          SchemaField("id", "string"),
+          SchemaField("name", "string"),
+          SchemaField("age", "integer")
+        ))
+
+        schema.fields should have size 3
+      }
+
+      it("should create a schema with description") {
+        val schema = SchemaDefinition(
+          Seq(SchemaField("id", "string")),
+          Some("User identifier schema")
+        )
+
+        schema.description shouldBe Some("User identifier schema")
+      }
+    }
+
+    describe("convenience methods") {
+
+      val schema = SchemaDefinition(Seq(
+        SchemaField("id", "string", nullable = false),
+        SchemaField("name", "string"),
+        SchemaField("age", "integer")
+      ))
+
+      it("should return field names") {
+        schema.fieldNames shouldBe Seq("id", "name", "age")
+      }
+
+      it("should find field by name") {
+        schema.field("name") shouldBe Some(SchemaField("name", "string"))
+        schema.field("unknown") shouldBe None
+      }
+
+      it("should check if field exists") {
+        schema.hasField("id") shouldBe true
+        schema.hasField("unknown") shouldBe false
+      }
+
+      it("should return size") {
+        schema.size shouldBe 3
+      }
+    }
+
+    describe("of factory method") {
+
+      it("should create schema from tuples") {
+        val schema = SchemaDefinition.of(
+          ("id", "string", false),
+          ("name", "string", true),
+          ("age", "integer", true)
+        )
+
+        schema.fields should have size 3
+        schema.field("id").get.nullable shouldBe false
+        schema.field("name").get.nullable shouldBe true
+      }
+    }
+  }
+
+  describe("SchemaValidationConfig") {
+
+    describe("defaults") {
+
+      it("should have validation disabled by default") {
+        val config = SchemaValidationConfig()
+
+        config.enabled shouldBe false
+        config.strict shouldBe false
+        config.failOnWarning shouldBe false
+      }
+
+      it("should provide an enabled preset") {
+        val config = SchemaValidationConfig.Enabled
+
+        config.enabled shouldBe true
+        config.strict shouldBe false
+      }
+
+      it("should provide a strict preset") {
+        val config = SchemaValidationConfig.Strict
+
+        config.enabled shouldBe true
+        config.strict shouldBe true
+        config.failOnWarning shouldBe true
+      }
+    }
+
+    describe("HOCON parsing") {
+
+      it("should parse schema-validation config") {
+        val hocon = ConfigFactory.parseString("""
+          enabled = true
+          strict = true
+          fail-on-warning = true
+        """)
+
+        val config = ConfigSource.fromConfig(hocon).loadOrThrow[SchemaValidationConfig]
+
+        config.enabled shouldBe true
+        config.strict shouldBe true
+        config.failOnWarning shouldBe true
+      }
+
+      it("should use defaults for missing fields") {
+        val hocon = ConfigFactory.parseString("""
+          enabled = true
+        """)
+
+        val config = ConfigSource.fromConfig(hocon).loadOrThrow[SchemaValidationConfig]
+
+        config.enabled shouldBe true
+        config.strict shouldBe false
+        config.failOnWarning shouldBe false
+      }
+    }
+  }
+
+  describe("SchemaValidator") {
+
+    describe("validate") {
+
+      it("should pass when schemas match exactly") {
+        val output = SchemaDefinition(Seq(
+          SchemaField("id", "string"),
+          SchemaField("name", "string")
+        ))
+        val input = SchemaDefinition(Seq(
+          SchemaField("id", "string"),
+          SchemaField("name", "string")
+        ))
+
+        val result = SchemaValidator.validate(output, input)
+
+        result.isValid shouldBe true
+        result.errors shouldBe empty
+      }
+
+      it("should pass when output has extra fields") {
+        val output = SchemaDefinition(Seq(
+          SchemaField("id", "string"),
+          SchemaField("name", "string"),
+          SchemaField("extra", "integer")
+        ))
+        val input = SchemaDefinition(Seq(
+          SchemaField("id", "string"),
+          SchemaField("name", "string")
+        ))
+
+        val result = SchemaValidator.validate(output, input)
+
+        result.isValid shouldBe true
+        result.warnings should have size 1
+        result.warnings.head.warningType shouldBe SchemaWarningType.ExtraFields
+      }
+
+      it("should fail when output is missing required fields") {
+        val output = SchemaDefinition(Seq(
+          SchemaField("id", "string")
+        ))
+        val input = SchemaDefinition(Seq(
+          SchemaField("id", "string"),
+          SchemaField("name", "string")
+        ))
+
+        val result = SchemaValidator.validate(output, input)
+
+        result.isValid shouldBe false
+        result.errors should have size 1
+        result.errors.head.errorType shouldBe SchemaErrorType.MissingField
+        result.errors.head.fieldName shouldBe Some("name")
+      }
+
+      it("should fail when field types don't match") {
+        val output = SchemaDefinition(Seq(
+          SchemaField("id", "string"),
+          SchemaField("count", "string")
+        ))
+        val input = SchemaDefinition(Seq(
+          SchemaField("id", "string"),
+          SchemaField("count", "integer")
+        ))
+
+        val result = SchemaValidator.validate(output, input)
+
+        result.isValid shouldBe false
+        result.errors should have size 1
+        result.errors.head.errorType shouldBe SchemaErrorType.TypeMismatch
+        result.errors.head.fieldName shouldBe Some("count")
+      }
+
+      it("should fail when non-nullable field is fed by nullable") {
+        val output = SchemaDefinition(Seq(
+          SchemaField("id", "string", nullable = true)
+        ))
+        val input = SchemaDefinition(Seq(
+          SchemaField("id", "string", nullable = false)
+        ))
+
+        val result = SchemaValidator.validate(output, input)
+
+        result.isValid shouldBe false
+        result.errors should have size 1
+        result.errors.head.errorType shouldBe SchemaErrorType.NullabilityViolation
+      }
+
+      it("should pass when nullable field is fed by non-nullable") {
+        val output = SchemaDefinition(Seq(
+          SchemaField("id", "string", nullable = false)
+        ))
+        val input = SchemaDefinition(Seq(
+          SchemaField("id", "string", nullable = true)
+        ))
+
+        val result = SchemaValidator.validate(output, input)
+
+        result.isValid shouldBe true
+      }
+
+      it("should collect multiple errors") {
+        val output = SchemaDefinition(Seq(
+          SchemaField("id", "integer")  // Wrong type
+        ))
+        val input = SchemaDefinition(Seq(
+          SchemaField("id", "string"),
+          SchemaField("name", "string"),  // Missing
+          SchemaField("age", "integer")   // Missing
+        ))
+
+        val result = SchemaValidator.validate(output, input)
+
+        result.isValid shouldBe false
+        result.errors should have size 3
+      }
+
+      it("should handle case-insensitive type comparison") {
+        val output = SchemaDefinition(Seq(
+          SchemaField("id", "STRING")
+        ))
+        val input = SchemaDefinition(Seq(
+          SchemaField("id", "string")
+        ))
+
+        val result = SchemaValidator.validate(output, input)
+
+        result.isValid shouldBe true
+      }
+    }
+
+    describe("validateComponents") {
+
+      trait TestContract extends SchemaContract
+
+      it("should skip validation when disabled") {
+        val config = SchemaValidationConfig(enabled = false)
+
+        val result = SchemaValidator.validateComponents(None, None, config)
+
+        result shouldBe SchemaValidationResult.Skipped
+      }
+
+      it("should skip when neither component has contracts") {
+        val config = SchemaValidationConfig(enabled = true)
+
+        val result = SchemaValidator.validateComponents(None, None, config)
+
+        result shouldBe SchemaValidationResult.Skipped
+      }
+
+      it("should warn when only producer has contract") {
+        val producer = new TestContract {
+          override def outputContract: Option[SchemaDefinition] = Some(
+            SchemaDefinition(Seq(SchemaField("id", "string")))
+          )
+        }
+        val config = SchemaValidationConfig(enabled = true)
+
+        val result = SchemaValidator.validateComponents(Some(producer), None, config)
+
+        result.isValid shouldBe true
+        result.warnings should have size 1
+        result.warnings.head.warningType shouldBe SchemaWarningType.PartialContract
+      }
+
+      it("should warn when only consumer has contract") {
+        val consumer = new TestContract {
+          override def inputContract: Option[SchemaDefinition] = Some(
+            SchemaDefinition(Seq(SchemaField("id", "string")))
+          )
+        }
+        val config = SchemaValidationConfig(enabled = true)
+
+        val result = SchemaValidator.validateComponents(None, Some(consumer), config)
+
+        result.isValid shouldBe true
+        result.warnings should have size 1
+      }
+
+      it("should validate when both have contracts") {
+        val producer = new TestContract {
+          override def outputContract: Option[SchemaDefinition] = Some(
+            SchemaDefinition(Seq(SchemaField("id", "string")))
+          )
+        }
+        val consumer = new TestContract {
+          override def inputContract: Option[SchemaDefinition] = Some(
+            SchemaDefinition(Seq(SchemaField("id", "string")))
+          )
+        }
+        val config = SchemaValidationConfig(enabled = true)
+
+        val result = SchemaValidator.validateComponents(Some(producer), Some(consumer), config)
+
+        result.isValid shouldBe true
+      }
+
+      it("should fail in strict mode when producer lacks contract") {
+        val consumer = new TestContract {
+          override def inputContract: Option[SchemaDefinition] = Some(
+            SchemaDefinition(Seq(SchemaField("id", "string")))
+          )
+        }
+        val config = SchemaValidationConfig(enabled = true, strict = true)
+
+        val result = SchemaValidator.validateComponents(None, Some(consumer), config)
+
+        result.isValid shouldBe false
+      }
+
+      it("should fail in strict mode when consumer lacks contract") {
+        val producer = new TestContract {
+          override def outputContract: Option[SchemaDefinition] = Some(
+            SchemaDefinition(Seq(SchemaField("id", "string")))
+          )
+        }
+        val config = SchemaValidationConfig(enabled = true, strict = true)
+
+        val result = SchemaValidator.validateComponents(Some(producer), None, config)
+
+        result.isValid shouldBe false
+      }
+
+      it("should fail in strict mode when neither has contracts") {
+        val config = SchemaValidationConfig(enabled = true, strict = true)
+
+        val result = SchemaValidator.validateComponents(None, None, config)
+
+        result.isValid shouldBe false
+      }
+    }
+  }
+
+  describe("SchemaValidationError") {
+
+    it("should format full message with all details") {
+      val error = SchemaValidationError(
+        errorType = SchemaErrorType.TypeMismatch,
+        message = "Field has incompatible type",
+        fieldName = Some("count"),
+        expected = Some("integer"),
+        actual = Some("string")
+      )
+
+      error.fullMessage should include("Field has incompatible type")
+      error.fullMessage should include("field: count")
+      error.fullMessage should include("expected: integer")
+      error.fullMessage should include("actual: string")
+    }
+
+    it("should format message without optional details") {
+      val error = SchemaValidationError(
+        errorType = SchemaErrorType.Incompatible,
+        message = "Schemas are incompatible"
+      )
+
+      error.fullMessage shouldBe "Schemas are incompatible"
+    }
+  }
+
+  describe("SchemaValidationWarning") {
+
+    it("should format message with field name") {
+      val warning = SchemaValidationWarning(
+        warningType = SchemaWarningType.ExtraFields,
+        message = "Extra field not consumed",
+        fieldName = Some("extra_column")
+      )
+
+      warning.fullMessage should include("extra_column")
+    }
+
+    it("should format message without field name") {
+      val warning = SchemaValidationWarning(
+        warningType = SchemaWarningType.PartialContract,
+        message = "Only one component has contract"
+      )
+
+      warning.fullMessage shouldBe "Only one component has contract"
+    }
+  }
+
+  describe("PipelineConfig with schema-validation") {
+
+    it("should parse pipeline config with schema-validation") {
+      val hocon = ConfigFactory.parseString("""
+        pipeline-name = "Test Pipeline"
+        schema-validation {
+          enabled = true
+          strict = false
+          fail-on-warning = true
+        }
+        pipeline-components = []
+      """)
+
+      val config = ConfigSource.fromConfig(hocon).loadOrThrow[PipelineConfig]
+
+      config.schemaValidation shouldBe defined
+      config.schemaValidation.get.enabled shouldBe true
+      config.schemaValidation.get.strict shouldBe false
+      config.schemaValidation.get.failOnWarning shouldBe true
+    }
+
+    it("should use None when schema-validation is not specified") {
+      val hocon = ConfigFactory.parseString("""
+        pipeline-name = "Test Pipeline"
+        pipeline-components = []
+      """)
+
+      val config = ConfigSource.fromConfig(hocon).loadOrThrow[PipelineConfig]
+
+      config.schemaValidation shouldBe None
+    }
+  }
+}

--- a/runner/src/test/scala/io/github/dwsmith1983/spark/pipeline/runner/SchemaValidationIntegrationSpec.scala
+++ b/runner/src/test/scala/io/github/dwsmith1983/spark/pipeline/runner/SchemaValidationIntegrationSpec.scala
@@ -1,0 +1,421 @@
+package io.github.dwsmith1983.spark.pipeline.runner
+
+import io.github.dwsmith1983.spark.pipeline.config._
+import io.github.dwsmith1983.spark.pipeline.runtime.{DataFlow, SparkSessionWrapper}
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.BeforeAndAfterAll
+import pureconfig._
+import pureconfig.generic.auto._
+
+import scala.collection.mutable
+
+/**
+ * Integration tests for schema contract validation in SimplePipelineRunner.
+ */
+class SchemaValidationIntegrationSpec
+  extends AnyFunSpec
+  with Matchers
+  with BeforeAndAfterEach
+  with BeforeAndAfterAll {
+
+  override def beforeEach(): Unit = {
+    SparkSessionWrapper.stop()
+    SchemaTestTracker.reset()
+  }
+
+  override def afterAll(): Unit =
+    SparkSessionWrapper.stop()
+
+  describe("SimplePipelineRunner schema validation") {
+
+    describe("disabled by default") {
+
+      it("should run without validation when schema-validation not configured") {
+        val config: Config = ConfigFactory.parseString("""
+          spark {
+            master = "local[1]"
+            app-name = "NoValidation"
+            config { "spark.ui.enabled" = "false" }
+          }
+          pipeline {
+            pipeline-name = "No Validation Test"
+            pipeline-components = [
+              {
+                instance-type = "io.github.dwsmith1983.spark.pipeline.runner.SchemaProducerComponent"
+                instance-name = "Producer"
+                instance-config { id = "producer-1" }
+              },
+              {
+                instance-type = "io.github.dwsmith1983.spark.pipeline.runner.SchemaConsumerComponent"
+                instance-name = "Consumer"
+                instance-config { id = "consumer-1" }
+              }
+            ]
+          }
+        """)
+
+        noException should be thrownBy {
+          SimplePipelineRunner.run(config)
+        }
+
+        SchemaTestTracker.executed should contain allOf ("producer-1", "consumer-1")
+      }
+    }
+
+    describe("with validation enabled") {
+
+      it("should pass validation when schemas are compatible") {
+        val config: Config = ConfigFactory.parseString("""
+          spark {
+            master = "local[1]"
+            app-name = "CompatibleSchemas"
+            config { "spark.ui.enabled" = "false" }
+          }
+          pipeline {
+            pipeline-name = "Compatible Schema Test"
+            schema-validation {
+              enabled = true
+            }
+            pipeline-components = [
+              {
+                instance-type = "io.github.dwsmith1983.spark.pipeline.runner.SchemaProducerComponent"
+                instance-name = "Producer"
+                instance-config { id = "producer-2" }
+              },
+              {
+                instance-type = "io.github.dwsmith1983.spark.pipeline.runner.CompatibleConsumerComponent"
+                instance-name = "Consumer"
+                instance-config { id = "consumer-2" }
+              }
+            ]
+          }
+        """)
+
+        noException should be thrownBy {
+          SimplePipelineRunner.run(config)
+        }
+
+        SchemaTestTracker.executed should contain allOf ("producer-2", "consumer-2")
+      }
+
+      it("should fail validation when schemas are incompatible") {
+        val config: Config = ConfigFactory.parseString("""
+          spark {
+            master = "local[1]"
+            app-name = "IncompatibleSchemas"
+            config { "spark.ui.enabled" = "false" }
+          }
+          pipeline {
+            pipeline-name = "Incompatible Schema Test"
+            schema-validation {
+              enabled = true
+            }
+            pipeline-components = [
+              {
+                instance-type = "io.github.dwsmith1983.spark.pipeline.runner.SchemaProducerComponent"
+                instance-name = "Producer"
+                instance-config { id = "producer-3" }
+              },
+              {
+                instance-type = "io.github.dwsmith1983.spark.pipeline.runner.IncompatibleConsumerComponent"
+                instance-name = "Consumer"
+                instance-config { id = "consumer-3" }
+              }
+            ]
+          }
+        """)
+
+        val exception = intercept[SchemaContractViolationException] {
+          SimplePipelineRunner.run(config)
+        }
+
+        exception.producerName shouldBe "Producer"
+        exception.consumerName shouldBe "Consumer"
+        exception.errors should not be empty
+
+        // Producer should have run, but consumer should not
+        SchemaTestTracker.executed should contain("producer-3")
+        SchemaTestTracker.executed should not contain "consumer-3"
+      }
+
+      it("should warn when only one component has schema") {
+        val config: Config = ConfigFactory.parseString("""
+          spark {
+            master = "local[1]"
+            app-name = "PartialSchema"
+            config { "spark.ui.enabled" = "false" }
+          }
+          pipeline {
+            pipeline-name = "Partial Schema Test"
+            schema-validation {
+              enabled = true
+            }
+            pipeline-components = [
+              {
+                instance-type = "io.github.dwsmith1983.spark.pipeline.runner.SchemaProducerComponent"
+                instance-name = "Producer"
+                instance-config { id = "producer-4" }
+              },
+              {
+                instance-type = "io.github.dwsmith1983.spark.pipeline.runner.NoSchemaComponent"
+                instance-name = "NoSchema"
+                instance-config { id = "no-schema-4" }
+              }
+            ]
+          }
+        """)
+
+        // Should not fail, just warn
+        noException should be thrownBy {
+          SimplePipelineRunner.run(config)
+        }
+
+        SchemaTestTracker.executed should contain allOf ("producer-4", "no-schema-4")
+      }
+    }
+
+    describe("strict mode") {
+
+      it("should fail in strict mode when component lacks schema") {
+        val config: Config = ConfigFactory.parseString("""
+          spark {
+            master = "local[1]"
+            app-name = "StrictMode"
+            config { "spark.ui.enabled" = "false" }
+          }
+          pipeline {
+            pipeline-name = "Strict Mode Test"
+            schema-validation {
+              enabled = true
+              strict = true
+            }
+            pipeline-components = [
+              {
+                instance-type = "io.github.dwsmith1983.spark.pipeline.runner.SchemaProducerComponent"
+                instance-name = "Producer"
+                instance-config { id = "producer-5" }
+              },
+              {
+                instance-type = "io.github.dwsmith1983.spark.pipeline.runner.NoSchemaComponent"
+                instance-name = "NoSchema"
+                instance-config { id = "no-schema-5" }
+              }
+            ]
+          }
+        """)
+
+        val exception = intercept[SchemaContractViolationException] {
+          SimplePipelineRunner.run(config)
+        }
+
+        exception.errors should not be empty
+      }
+    }
+
+    describe("fail-on-warning mode") {
+
+      it("should fail when warnings occur with fail-on-warning enabled") {
+        val config: Config = ConfigFactory.parseString("""
+          spark {
+            master = "local[1]"
+            app-name = "FailOnWarning"
+            config { "spark.ui.enabled" = "false" }
+          }
+          pipeline {
+            pipeline-name = "Fail On Warning Test"
+            schema-validation {
+              enabled = true
+              fail-on-warning = true
+            }
+            pipeline-components = [
+              {
+                instance-type = "io.github.dwsmith1983.spark.pipeline.runner.SchemaProducerComponent"
+                instance-name = "Producer"
+                instance-config { id = "producer-6" }
+              },
+              {
+                instance-type = "io.github.dwsmith1983.spark.pipeline.runner.NoSchemaComponent"
+                instance-name = "NoSchema"
+                instance-config { id = "no-schema-6" }
+              }
+            ]
+          }
+        """)
+
+        val exception = intercept[SchemaContractViolationException] {
+          SimplePipelineRunner.run(config)
+        }
+
+        exception.warnings should not be empty
+      }
+    }
+
+    describe("continue-on-error mode with schema validation") {
+
+      it("should continue after schema violation with failFast=false") {
+        val config: Config = ConfigFactory.parseString("""
+          spark {
+            master = "local[1]"
+            app-name = "ContinueOnError"
+            config { "spark.ui.enabled" = "false" }
+          }
+          pipeline {
+            pipeline-name = "Continue On Error Test"
+            fail-fast = false
+            schema-validation {
+              enabled = true
+            }
+            pipeline-components = [
+              {
+                instance-type = "io.github.dwsmith1983.spark.pipeline.runner.SchemaProducerComponent"
+                instance-name = "Producer"
+                instance-config { id = "producer-7" }
+              },
+              {
+                instance-type = "io.github.dwsmith1983.spark.pipeline.runner.IncompatibleConsumerComponent"
+                instance-name = "BadConsumer"
+                instance-config { id = "bad-consumer-7" }
+              },
+              {
+                instance-type = "io.github.dwsmith1983.spark.pipeline.runner.NoSchemaComponent"
+                instance-name = "ThirdComponent"
+                instance-config { id = "third-7" }
+              }
+            ]
+          }
+        """)
+
+        // Should not throw, but should record failure
+        noException should be thrownBy {
+          SimplePipelineRunner.run(config)
+        }
+
+        // First component ran
+        SchemaTestTracker.executed should contain("producer-7")
+        // Second component was skipped due to schema violation
+        SchemaTestTracker.executed should not contain "bad-consumer-7"
+        // Third component ran (after failure was recorded)
+        SchemaTestTracker.executed should contain("third-7")
+      }
+    }
+  }
+}
+
+// =============================================================================
+// TEST FIXTURES FOR SCHEMA VALIDATION
+// =============================================================================
+
+/** Tracks execution for schema validation tests. */
+object SchemaTestTracker {
+  val executed: mutable.ListBuffer[String] = mutable.ListBuffer.empty
+
+  def reset(): Unit = executed.clear()
+}
+
+// Producer with output schema
+case class SchemaProducerConfig(id: String)
+
+object SchemaProducerComponent extends ConfigurableInstance {
+  override def createFromConfig(conf: Config): SchemaProducerComponent =
+    new SchemaProducerComponent(ConfigSource.fromConfig(conf).loadOrThrow[SchemaProducerConfig])
+}
+
+class SchemaProducerComponent(conf: SchemaProducerConfig) extends DataFlow with SchemaContract {
+  override def outputContract: Option[SchemaDefinition] = Some(
+    SchemaDefinition(Seq(
+      SchemaField("id", "long", nullable = false),
+      SchemaField("name", "string"),
+      SchemaField("value", "double")
+    ))
+  )
+
+  override def run(): Unit = {
+    logger.info(s"SchemaProducerComponent running: ${conf.id}")
+    SchemaTestTracker.executed += conf.id
+  }
+}
+
+// Consumer with input schema (no output schema for testing)
+case class SchemaConsumerConfig(id: String)
+
+object SchemaConsumerComponent extends ConfigurableInstance {
+  override def createFromConfig(conf: Config): SchemaConsumerComponent =
+    new SchemaConsumerComponent(ConfigSource.fromConfig(conf).loadOrThrow[SchemaConsumerConfig])
+}
+
+class SchemaConsumerComponent(conf: SchemaConsumerConfig) extends DataFlow with SchemaContract {
+  override def inputContract: Option[SchemaDefinition] = Some(
+    SchemaDefinition(Seq(
+      SchemaField("id", "long"),
+      SchemaField("name", "string")
+    ))
+  )
+
+  override def run(): Unit = {
+    logger.info(s"SchemaConsumerComponent running: ${conf.id}")
+    SchemaTestTracker.executed += conf.id
+  }
+}
+
+// Compatible consumer (subset of producer output)
+case class CompatibleConsumerConfig(id: String)
+
+object CompatibleConsumerComponent extends ConfigurableInstance {
+  override def createFromConfig(conf: Config): CompatibleConsumerComponent =
+    new CompatibleConsumerComponent(ConfigSource.fromConfig(conf).loadOrThrow[CompatibleConsumerConfig])
+}
+
+class CompatibleConsumerComponent(conf: CompatibleConsumerConfig) extends DataFlow with SchemaContract {
+  override def inputContract: Option[SchemaDefinition] = Some(
+    SchemaDefinition(Seq(
+      SchemaField("id", "long"),
+      SchemaField("name", "string")
+    ))
+  )
+
+  override def run(): Unit = {
+    logger.info(s"CompatibleConsumerComponent running: ${conf.id}")
+    SchemaTestTracker.executed += conf.id
+  }
+}
+
+// Incompatible consumer (requires field not in producer output)
+case class IncompatibleConsumerConfig(id: String)
+
+object IncompatibleConsumerComponent extends ConfigurableInstance {
+  override def createFromConfig(conf: Config): IncompatibleConsumerComponent =
+    new IncompatibleConsumerComponent(ConfigSource.fromConfig(conf).loadOrThrow[IncompatibleConsumerConfig])
+}
+
+class IncompatibleConsumerComponent(conf: IncompatibleConsumerConfig) extends DataFlow with SchemaContract {
+  override def inputContract: Option[SchemaDefinition] = Some(
+    SchemaDefinition(Seq(
+      SchemaField("id", "long"),
+      SchemaField("name", "string"),
+      SchemaField("missing_field", "integer")  // This field is not in producer output
+    ))
+  )
+
+  override def run(): Unit = {
+    logger.info(s"IncompatibleConsumerComponent running: ${conf.id}")
+    SchemaTestTracker.executed += conf.id
+  }
+}
+
+// Component without schema contract
+case class NoSchemaConfig(id: String)
+
+object NoSchemaComponent extends ConfigurableInstance {
+  override def createFromConfig(conf: Config): NoSchemaComponent =
+    new NoSchemaComponent(ConfigSource.fromConfig(conf).loadOrThrow[NoSchemaConfig])
+}
+
+class NoSchemaComponent(conf: NoSchemaConfig) extends DataFlow {
+  override def run(): Unit = {
+    logger.info(s"NoSchemaComponent running: ${conf.id}")
+    SchemaTestTracker.executed += conf.id
+  }
+}

--- a/runtime/src/main/scala/io/github/dwsmith1983/spark/pipeline/runtime/SparkSchemaConverter.scala
+++ b/runtime/src/main/scala/io/github/dwsmith1983/spark/pipeline/runtime/SparkSchemaConverter.scala
@@ -1,0 +1,251 @@
+package io.github.dwsmith1983.spark.pipeline.runtime
+
+import io.github.dwsmith1983.spark.pipeline.config.{SchemaDefinition, SchemaField}
+import org.apache.spark.sql.types._
+
+/**
+ * Converts between platform-independent schema definitions and Spark StructType.
+ *
+ * This converter enables schema contracts defined in the core module to be
+ * validated against actual Spark DataFrame schemas at runtime.
+ *
+ * == Supported Data Types ==
+ *
+ * The following data type strings are recognized:
+ *
+ * | String          | Spark Type       |
+ * |-----------------|------------------|
+ * | string          | StringType       |
+ * | integer, int    | IntegerType      |
+ * | long, bigint    | LongType         |
+ * | double          | DoubleType       |
+ * | float           | FloatType        |
+ * | boolean, bool   | BooleanType      |
+ * | timestamp       | TimestampType    |
+ * | date            | DateType         |
+ * | binary          | BinaryType       |
+ * | byte, tinyint   | ByteType         |
+ * | short, smallint | ShortType        |
+ * | decimal(p,s)    | DecimalType(p,s) |
+ *
+ * Complex types (array, map, struct) are partially supported for conversion
+ * from Spark to SchemaDefinition, but not yet for the reverse direction.
+ */
+object SparkSchemaConverter {
+
+  /**
+   * Converts a SchemaDefinition to a Spark StructType.
+   *
+   * @param schema The platform-independent schema definition
+   * @return The equivalent Spark StructType
+   */
+  def toStructType(schema: SchemaDefinition): StructType =
+    StructType(schema.fields.map(toStructField))
+
+  /**
+   * Converts a SchemaField to a Spark StructField.
+   *
+   * @param field The platform-independent field definition
+   * @return The equivalent Spark StructField
+   */
+  def toStructField(field: SchemaField): StructField = {
+    val sparkType = toSparkType(field.normalizedDataType)
+    val metadata = if (field.metadata.isEmpty) {
+      Metadata.empty
+    } else {
+      val builder = new MetadataBuilder()
+      field.metadata.foreach { case (k, v) => builder.putString(k, v) }
+      builder.build()
+    }
+    StructField(field.name, sparkType, field.nullable, metadata)
+  }
+
+  /**
+   * Converts a data type string to a Spark DataType.
+   *
+   * @param dataType The data type string (e.g., "string", "integer", "decimal(10,2)")
+   * @return The equivalent Spark DataType
+   */
+  def toSparkType(dataType: String): DataType = {
+    val normalized = dataType.toLowerCase.trim
+
+    normalized match {
+      case "string"                                 => StringType
+      case "integer" | "int"                        => IntegerType
+      case "long" | "bigint"                        => LongType
+      case "double"                                 => DoubleType
+      case "float"                                  => FloatType
+      case "boolean" | "bool"                       => BooleanType
+      case "timestamp"                              => TimestampType
+      case "date"                                   => DateType
+      case "binary"                                 => BinaryType
+      case "byte" | "tinyint"                       => ByteType
+      case "short" | "smallint"                     => ShortType
+      case decimal if decimal.startsWith("decimal") => parseDecimalType(decimal)
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Unsupported data type: $dataType. " +
+            "Supported types: string, integer, long, double, float, boolean, " +
+            "timestamp, date, binary, byte, short, decimal(precision,scale)"
+        )
+    }
+  }
+
+  /**
+   * Converts a Spark StructType to a SchemaDefinition.
+   *
+   * @param structType The Spark StructType
+   * @param description Optional description for the schema
+   * @return The equivalent platform-independent SchemaDefinition
+   */
+  def fromStructType(structType: StructType, description: Option[String] = None): SchemaDefinition =
+    SchemaDefinition(
+      fields = structType.fields.map(fromStructField).toSeq,
+      description = description
+    )
+
+  /**
+   * Converts a Spark StructField to a SchemaField.
+   *
+   * @param field The Spark StructField
+   * @return The equivalent platform-independent SchemaField
+   */
+  def fromStructField(field: StructField): SchemaField = {
+    val metadata: Map[String, String] = {
+      val meta = field.metadata
+      if (meta == Metadata.empty) {
+        Map.empty
+      } else {
+        // Extract string values from metadata (limited support)
+        val builder = Map.newBuilder[String, String]
+        try {
+          val json = meta.json
+          if (json != "{}") {
+            builder += ("_raw" -> json)
+          }
+        } catch {
+          case _: Exception => // Ignore metadata extraction errors
+        }
+        builder.result()
+      }
+    }
+
+    SchemaField(
+      name = field.name,
+      dataType = fromSparkType(field.dataType),
+      nullable = field.nullable,
+      metadata = metadata
+    )
+  }
+
+  /**
+   * Converts a Spark DataType to a data type string.
+   *
+   * @param dataType The Spark DataType
+   * @return The equivalent data type string
+   */
+  def fromSparkType(dataType: DataType): String = dataType match {
+    case StringType         => "string"
+    case IntegerType        => "integer"
+    case LongType           => "long"
+    case DoubleType         => "double"
+    case FloatType          => "float"
+    case BooleanType        => "boolean"
+    case TimestampType      => "timestamp"
+    case DateType           => "date"
+    case BinaryType         => "binary"
+    case ByteType           => "byte"
+    case ShortType          => "short"
+    case d: DecimalType     => s"decimal(${d.precision},${d.scale})"
+    case ArrayType(et, _)   => s"array<${fromSparkType(et)}>"
+    case MapType(kt, vt, _) => s"map<${fromSparkType(kt)},${fromSparkType(vt)}>"
+    case st: StructType     => s"struct<${st.fields.map(f => s"${f.name}:${fromSparkType(f.dataType)}").mkString(",")}>"
+    case _                  => dataType.typeName
+  }
+
+  /**
+   * Checks if a Spark DataFrame's schema is compatible with an expected SchemaDefinition.
+   *
+   * Compatibility means:
+   *   - All expected fields exist in the actual schema
+   *   - Field types match (using normalized comparison)
+   *   - Nullability constraints are satisfied
+   *
+   * @param expected The expected schema definition
+   * @param actual   The actual Spark StructType
+   * @return true if compatible, false otherwise
+   */
+  def isCompatible(expected: SchemaDefinition, actual: StructType): Boolean = {
+    val actualFields = actual.fields.map(f => f.name -> f).toMap
+
+    expected.fields.forall { expectedField =>
+      actualFields.get(expectedField.name) match {
+        case None => false
+        case Some(actualField) =>
+          val typeMatch = normalizeTypeName(fromSparkType(actualField.dataType)) ==
+            normalizeTypeName(expectedField.dataType)
+          val nullabilityOk = expectedField.nullable || !actualField.nullable
+          typeMatch && nullabilityOk
+      }
+    }
+  }
+
+  /**
+   * Validates an actual Spark StructType against an expected SchemaDefinition.
+   *
+   * @param expected The expected schema definition
+   * @param actual   The actual Spark StructType
+   * @return List of validation error messages (empty if valid)
+   */
+  def validateAgainst(expected: SchemaDefinition, actual: StructType): List[String] = {
+    val errors = scala.collection.mutable.ListBuffer.empty[String]
+    val actualFields = actual.fields.map(f => f.name -> f).toMap
+
+    expected.fields.foreach { expectedField =>
+      actualFields.get(expectedField.name) match {
+        case None =>
+          errors += s"Missing field: ${expectedField.name} (expected type: ${expectedField.dataType})"
+
+        case Some(actualField) =>
+          val actualTypeName = fromSparkType(actualField.dataType)
+          if (normalizeTypeName(actualTypeName) != normalizeTypeName(expectedField.dataType)) {
+            errors += s"Type mismatch for field '${expectedField.name}': " +
+              s"expected ${expectedField.dataType}, found $actualTypeName"
+          }
+
+          if (!expectedField.nullable && actualField.nullable) {
+            errors += s"Nullability violation for field '${expectedField.name}': " +
+              "expected non-nullable, but field is nullable"
+          }
+      }
+    }
+
+    errors.toList
+  }
+
+  private def parseDecimalType(decimalStr: String): DecimalType = {
+    val pattern = """decimal\s*\(\s*(\d+)\s*,\s*(\d+)\s*\)""".r
+    decimalStr match {
+      case pattern(precision, scale) =>
+        DecimalType(precision.toInt, scale.toInt)
+      case "decimal" =>
+        DecimalType.SYSTEM_DEFAULT
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Invalid decimal type format: $decimalStr. Expected: decimal(precision,scale)"
+        )
+    }
+  }
+
+  private def normalizeTypeName(typeName: String): String = {
+    val normalized = typeName.toLowerCase.trim
+    normalized match {
+      case "int"      => "integer"
+      case "bigint"   => "long"
+      case "bool"     => "boolean"
+      case "tinyint"  => "byte"
+      case "smallint" => "short"
+      case other      => other
+    }
+  }
+}

--- a/runtime/src/test/scala/io/github/dwsmith1983/spark/pipeline/runtime/SparkSchemaConverterSpec.scala
+++ b/runtime/src/test/scala/io/github/dwsmith1983/spark/pipeline/runtime/SparkSchemaConverterSpec.scala
@@ -1,0 +1,473 @@
+package io.github.dwsmith1983.spark.pipeline.runtime
+
+import io.github.dwsmith1983.spark.pipeline.config.{SchemaDefinition, SchemaField, SparkConfig}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterAll
+
+/**
+ * Tests for SparkSchemaConverter.
+ */
+class SparkSchemaConverterSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll {
+
+  var spark: SparkSession = _
+
+  override def beforeAll(): Unit = {
+    val config: SparkConfig = SparkConfig(
+      master = Some("local[2]"),
+      appName = Some("SparkSchemaConverterTest"),
+      config = Map(
+        "spark.ui.enabled"             -> "false",
+        "spark.sql.shuffle.partitions" -> "2"
+      )
+    )
+    spark = SparkSessionWrapper.configure(config)
+  }
+
+  override def afterAll(): Unit =
+    SparkSessionWrapper.stop()
+
+  describe("SparkSchemaConverter") {
+
+    describe("toSparkType") {
+
+      it("should convert string type") {
+        SparkSchemaConverter.toSparkType("string") shouldBe StringType
+        SparkSchemaConverter.toSparkType("STRING") shouldBe StringType
+      }
+
+      it("should convert integer types") {
+        SparkSchemaConverter.toSparkType("integer") shouldBe IntegerType
+        SparkSchemaConverter.toSparkType("int") shouldBe IntegerType
+      }
+
+      it("should convert long types") {
+        SparkSchemaConverter.toSparkType("long") shouldBe LongType
+        SparkSchemaConverter.toSparkType("bigint") shouldBe LongType
+      }
+
+      it("should convert double type") {
+        SparkSchemaConverter.toSparkType("double") shouldBe DoubleType
+      }
+
+      it("should convert float type") {
+        SparkSchemaConverter.toSparkType("float") shouldBe FloatType
+      }
+
+      it("should convert boolean types") {
+        SparkSchemaConverter.toSparkType("boolean") shouldBe BooleanType
+        SparkSchemaConverter.toSparkType("bool") shouldBe BooleanType
+      }
+
+      it("should convert timestamp type") {
+        SparkSchemaConverter.toSparkType("timestamp") shouldBe TimestampType
+      }
+
+      it("should convert date type") {
+        SparkSchemaConverter.toSparkType("date") shouldBe DateType
+      }
+
+      it("should convert binary type") {
+        SparkSchemaConverter.toSparkType("binary") shouldBe BinaryType
+      }
+
+      it("should convert byte types") {
+        SparkSchemaConverter.toSparkType("byte") shouldBe ByteType
+        SparkSchemaConverter.toSparkType("tinyint") shouldBe ByteType
+      }
+
+      it("should convert short types") {
+        SparkSchemaConverter.toSparkType("short") shouldBe ShortType
+        SparkSchemaConverter.toSparkType("smallint") shouldBe ShortType
+      }
+
+      it("should convert decimal type with precision and scale") {
+        val decimalType = SparkSchemaConverter.toSparkType("decimal(10,2)")
+        decimalType shouldBe a[DecimalType]
+        decimalType.asInstanceOf[DecimalType].precision shouldBe 10
+        decimalType.asInstanceOf[DecimalType].scale shouldBe 2
+      }
+
+      it("should convert decimal type without precision") {
+        val decimalType = SparkSchemaConverter.toSparkType("decimal")
+        decimalType shouldBe a[DecimalType]
+      }
+
+      it("should throw on unsupported type") {
+        val exception = intercept[IllegalArgumentException] {
+          SparkSchemaConverter.toSparkType("unsupported_type")
+        }
+        exception.getMessage should include("Unsupported data type")
+      }
+    }
+
+    describe("fromSparkType") {
+
+      it("should convert StringType") {
+        SparkSchemaConverter.fromSparkType(StringType) shouldBe "string"
+      }
+
+      it("should convert IntegerType") {
+        SparkSchemaConverter.fromSparkType(IntegerType) shouldBe "integer"
+      }
+
+      it("should convert LongType") {
+        SparkSchemaConverter.fromSparkType(LongType) shouldBe "long"
+      }
+
+      it("should convert DoubleType") {
+        SparkSchemaConverter.fromSparkType(DoubleType) shouldBe "double"
+      }
+
+      it("should convert FloatType") {
+        SparkSchemaConverter.fromSparkType(FloatType) shouldBe "float"
+      }
+
+      it("should convert BooleanType") {
+        SparkSchemaConverter.fromSparkType(BooleanType) shouldBe "boolean"
+      }
+
+      it("should convert TimestampType") {
+        SparkSchemaConverter.fromSparkType(TimestampType) shouldBe "timestamp"
+      }
+
+      it("should convert DateType") {
+        SparkSchemaConverter.fromSparkType(DateType) shouldBe "date"
+      }
+
+      it("should convert DecimalType with precision and scale") {
+        SparkSchemaConverter.fromSparkType(DecimalType(18, 4)) shouldBe "decimal(18,4)"
+      }
+
+      it("should convert ArrayType") {
+        SparkSchemaConverter.fromSparkType(ArrayType(StringType)) shouldBe "array<string>"
+      }
+
+      it("should convert MapType") {
+        SparkSchemaConverter.fromSparkType(MapType(StringType, IntegerType)) shouldBe "map<string,integer>"
+      }
+    }
+
+    describe("toStructField") {
+
+      it("should convert a nullable field") {
+        val field = SchemaField("name", "string", nullable = true)
+        val structField = SparkSchemaConverter.toStructField(field)
+
+        structField.name shouldBe "name"
+        structField.dataType shouldBe StringType
+        structField.nullable shouldBe true
+      }
+
+      it("should convert a non-nullable field") {
+        val field = SchemaField("id", "integer", nullable = false)
+        val structField = SparkSchemaConverter.toStructField(field)
+
+        structField.name shouldBe "id"
+        structField.dataType shouldBe IntegerType
+        structField.nullable shouldBe false
+      }
+
+      it("should include metadata") {
+        val field = SchemaField("amount", "decimal", metadata = Map("precision" -> "10"))
+        val structField = SparkSchemaConverter.toStructField(field)
+
+        structField.metadata.getString("precision") shouldBe "10"
+      }
+    }
+
+    describe("fromStructField") {
+
+      it("should convert a StructField to SchemaField") {
+        val structField = StructField("name", StringType, nullable = true)
+        val schemaField = SparkSchemaConverter.fromStructField(structField)
+
+        schemaField.name shouldBe "name"
+        schemaField.dataType shouldBe "string"
+        schemaField.nullable shouldBe true
+      }
+
+      it("should handle non-nullable fields") {
+        val structField = StructField("id", LongType, nullable = false)
+        val schemaField = SparkSchemaConverter.fromStructField(structField)
+
+        schemaField.nullable shouldBe false
+      }
+    }
+
+    describe("toStructType") {
+
+      it("should convert a SchemaDefinition to StructType") {
+        val schema = SchemaDefinition(Seq(
+          SchemaField("id", "long", nullable = false),
+          SchemaField("name", "string"),
+          SchemaField("age", "integer")
+        ))
+
+        val structType = SparkSchemaConverter.toStructType(schema)
+
+        structType.fields should have size 3
+        structType("id").dataType shouldBe LongType
+        structType("id").nullable shouldBe false
+        structType("name").dataType shouldBe StringType
+        structType("age").dataType shouldBe IntegerType
+      }
+
+      it("should handle empty schema") {
+        val schema = SchemaDefinition.empty
+        val structType = SparkSchemaConverter.toStructType(schema)
+
+        structType.fields shouldBe empty
+      }
+    }
+
+    describe("fromStructType") {
+
+      it("should convert a StructType to SchemaDefinition") {
+        val structType = StructType(Seq(
+          StructField("id", LongType, nullable = false),
+          StructField("name", StringType),
+          StructField("amount", DecimalType(10, 2))
+        ))
+
+        val schema = SparkSchemaConverter.fromStructType(structType)
+
+        schema.fields should have size 3
+        schema.field("id").get.dataType shouldBe "long"
+        schema.field("id").get.nullable shouldBe false
+        schema.field("amount").get.dataType shouldBe "decimal(10,2)"
+      }
+
+      it("should include description if provided") {
+        val structType = StructType(Seq(StructField("id", LongType)))
+        val schema = SparkSchemaConverter.fromStructType(structType, Some("User table"))
+
+        schema.description shouldBe Some("User table")
+      }
+    }
+
+    describe("isCompatible") {
+
+      it("should return true when schemas match") {
+        val expected = SchemaDefinition(Seq(
+          SchemaField("id", "long"),
+          SchemaField("name", "string")
+        ))
+        val actual = StructType(Seq(
+          StructField("id", LongType),
+          StructField("name", StringType)
+        ))
+
+        SparkSchemaConverter.isCompatible(expected, actual) shouldBe true
+      }
+
+      it("should return true when actual has extra fields") {
+        val expected = SchemaDefinition(Seq(
+          SchemaField("id", "long")
+        ))
+        val actual = StructType(Seq(
+          StructField("id", LongType),
+          StructField("extra", StringType)
+        ))
+
+        SparkSchemaConverter.isCompatible(expected, actual) shouldBe true
+      }
+
+      it("should return false when expected field is missing") {
+        val expected = SchemaDefinition(Seq(
+          SchemaField("id", "long"),
+          SchemaField("name", "string")
+        ))
+        val actual = StructType(Seq(
+          StructField("id", LongType)
+        ))
+
+        SparkSchemaConverter.isCompatible(expected, actual) shouldBe false
+      }
+
+      it("should return false when types don't match") {
+        val expected = SchemaDefinition(Seq(
+          SchemaField("id", "long")
+        ))
+        val actual = StructType(Seq(
+          StructField("id", StringType)
+        ))
+
+        SparkSchemaConverter.isCompatible(expected, actual) shouldBe false
+      }
+
+      it("should return false when nullability is violated") {
+        val expected = SchemaDefinition(Seq(
+          SchemaField("id", "long", nullable = false)
+        ))
+        val actual = StructType(Seq(
+          StructField("id", LongType, nullable = true)
+        ))
+
+        SparkSchemaConverter.isCompatible(expected, actual) shouldBe false
+      }
+
+      it("should handle type aliases") {
+        val expected = SchemaDefinition(Seq(
+          SchemaField("id", "int"),
+          SchemaField("count", "bigint")
+        ))
+        val actual = StructType(Seq(
+          StructField("id", IntegerType),
+          StructField("count", LongType)
+        ))
+
+        SparkSchemaConverter.isCompatible(expected, actual) shouldBe true
+      }
+    }
+
+    describe("validateAgainst") {
+
+      it("should return empty list when valid") {
+        val expected = SchemaDefinition(Seq(
+          SchemaField("id", "long"),
+          SchemaField("name", "string")
+        ))
+        val actual = StructType(Seq(
+          StructField("id", LongType),
+          StructField("name", StringType)
+        ))
+
+        SparkSchemaConverter.validateAgainst(expected, actual) shouldBe empty
+      }
+
+      it("should return errors for missing fields") {
+        val expected = SchemaDefinition(Seq(
+          SchemaField("id", "long"),
+          SchemaField("name", "string")
+        ))
+        val actual = StructType(Seq(
+          StructField("id", LongType)
+        ))
+
+        val errors = SparkSchemaConverter.validateAgainst(expected, actual)
+
+        errors should have size 1
+        errors.head should include("Missing field")
+        errors.head should include("name")
+      }
+
+      it("should return errors for type mismatches") {
+        val expected = SchemaDefinition(Seq(
+          SchemaField("id", "long")
+        ))
+        val actual = StructType(Seq(
+          StructField("id", StringType)
+        ))
+
+        val errors = SparkSchemaConverter.validateAgainst(expected, actual)
+
+        errors should have size 1
+        errors.head should include("Type mismatch")
+      }
+
+      it("should return errors for nullability violations") {
+        val expected = SchemaDefinition(Seq(
+          SchemaField("id", "long", nullable = false)
+        ))
+        val actual = StructType(Seq(
+          StructField("id", LongType, nullable = true)
+        ))
+
+        val errors = SparkSchemaConverter.validateAgainst(expected, actual)
+
+        errors should have size 1
+        errors.head should include("Nullability violation")
+      }
+
+      it("should collect multiple errors") {
+        val expected = SchemaDefinition(Seq(
+          SchemaField("id", "string"),  // Wrong type
+          SchemaField("missing", "long")  // Missing
+        ))
+        val actual = StructType(Seq(
+          StructField("id", LongType)
+        ))
+
+        val errors = SparkSchemaConverter.validateAgainst(expected, actual)
+
+        errors should have size 2
+      }
+    }
+
+    describe("round-trip conversion") {
+
+      it("should preserve schema through round-trip") {
+        val original = SchemaDefinition(Seq(
+          SchemaField("id", "long", nullable = false),
+          SchemaField("name", "string"),
+          SchemaField("amount", "double"),
+          SchemaField("active", "boolean")
+        ))
+
+        val structType = SparkSchemaConverter.toStructType(original)
+        val roundTrip = SparkSchemaConverter.fromStructType(structType)
+
+        roundTrip.fieldNames shouldBe original.fieldNames
+        roundTrip.fields.zip(original.fields).foreach { case (rt, orig) =>
+          rt.name shouldBe orig.name
+          rt.nullable shouldBe orig.nullable
+        }
+      }
+    }
+
+    describe("integration with real DataFrames") {
+
+      it("should validate actual DataFrame schema") {
+        val df = spark.sql("""
+          SELECT
+            1L as id,
+            'Alice' as name,
+            25 as age
+        """)
+
+        val expected = SchemaDefinition(Seq(
+          SchemaField("id", "long"),
+          SchemaField("name", "string"),
+          SchemaField("age", "integer")
+        ))
+
+        SparkSchemaConverter.isCompatible(expected, df.schema) shouldBe true
+      }
+
+      it("should detect missing columns in DataFrame") {
+        val df = spark.sql("SELECT 1L as id")
+
+        val expected = SchemaDefinition(Seq(
+          SchemaField("id", "long"),
+          SchemaField("name", "string")
+        ))
+
+        SparkSchemaConverter.isCompatible(expected, df.schema) shouldBe false
+      }
+
+      it("should work with complex schemas") {
+        val df = spark.sql("""
+          SELECT
+            1L as id,
+            'test' as name,
+            cast(10.5 as double) as amount,
+            true as active,
+            current_timestamp() as created_at
+        """)
+
+        val expected = SchemaDefinition(Seq(
+          SchemaField("id", "long"),
+          SchemaField("name", "string"),
+          SchemaField("amount", "double"),
+          SchemaField("active", "boolean"),
+          SchemaField("created_at", "timestamp")
+        ))
+
+        SparkSchemaConverter.isCompatible(expected, df.schema) shouldBe true
+      }
+    }
+  }
+}

--- a/website/docs/schema-contracts.md
+++ b/website/docs/schema-contracts.md
@@ -1,0 +1,239 @@
+# Schema Contracts
+
+Schema contracts allow pipeline components to declare their expected input and output schemas. When enabled, the framework validates schema compatibility between adjacent components at runtime, catching mismatches early with clear error messages.
+
+## Overview
+
+By default, components don't declare or validate their schemas. If Component A outputs a DataFrame missing columns that Component B expects, the pipeline fails at runtime with unclear errors deep in component execution.
+
+Schema contracts solve this by:
+
+- Allowing components to optionally declare input/output schemas
+- Validating schema compatibility between adjacent components before execution
+- Providing clear error messages when schemas don't match
+
+## Basic Usage
+
+### Declaring Schema Contracts
+
+Extend the `SchemaContract` trait and implement `inputContract` and/or `outputContract`:
+
+```scala
+import io.github.dwsmith1983.spark.pipeline.config.{SchemaContract, SchemaDefinition, SchemaField}
+import io.github.dwsmith1983.spark.pipeline.runtime.DataFlow
+
+class MyTransform(conf: MyTransform.Config) extends DataFlow with SchemaContract {
+
+  // Declare expected input schema
+  override def inputContract: Option[SchemaDefinition] = Some(
+    SchemaDefinition(Seq(
+      SchemaField("user_id", "string", nullable = false),
+      SchemaField("transaction_date", "date"),
+      SchemaField("amount", "double")
+    ))
+  )
+
+  // Declare produced output schema
+  override def outputContract: Option[SchemaDefinition] = Some(
+    SchemaDefinition(Seq(
+      SchemaField("user_id", "string", nullable = false),
+      SchemaField("transaction_date", "date"),
+      SchemaField("amount", "double"),
+      SchemaField("processed_at", "timestamp")  // Added field
+    ))
+  )
+
+  override def run(): Unit = {
+    // Implementation
+  }
+}
+```
+
+### Enabling Validation
+
+Enable schema validation in your pipeline configuration:
+
+```hocon
+pipeline {
+  pipeline-name = "My Data Pipeline"
+
+  schema-validation {
+    enabled = true
+  }
+
+  pipeline-components = [
+    { ... }
+  ]
+}
+```
+
+## Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `false` | Enable schema validation between components |
+| `strict` | `false` | Require all components to have schema contracts |
+| `fail-on-warning` | `false` | Treat validation warnings as errors |
+
+### Example Configuration
+
+```hocon
+pipeline {
+  pipeline-name = "Strict Schema Pipeline"
+
+  schema-validation {
+    enabled = true
+    strict = true           # All components must declare schemas
+    fail-on-warning = true  # Warnings become errors
+  }
+
+  pipeline-components = [...]
+}
+```
+
+## Supported Data Types
+
+Schema contracts use string-based data types that map to Spark types:
+
+| String | Spark Type |
+|--------|------------|
+| `string` | `StringType` |
+| `integer`, `int` | `IntegerType` |
+| `long`, `bigint` | `LongType` |
+| `double` | `DoubleType` |
+| `float` | `FloatType` |
+| `boolean`, `bool` | `BooleanType` |
+| `timestamp` | `TimestampType` |
+| `date` | `DateType` |
+| `binary` | `BinaryType` |
+| `byte`, `tinyint` | `ByteType` |
+| `short`, `smallint` | `ShortType` |
+| `decimal(p,s)` | `DecimalType(p,s)` |
+
+## Validation Rules
+
+### Compatibility Checking
+
+For a producer's output to be compatible with a consumer's input:
+
+1. **All required fields must exist**: Every field in the consumer's input contract must exist in the producer's output contract
+2. **Types must match**: Field types must be identical (case-insensitive comparison)
+3. **Nullability must be satisfied**: Non-nullable consumer fields cannot be fed by nullable producer fields
+
+### Validation Behavior
+
+| Scenario | Behavior |
+|----------|----------|
+| Neither component has contracts | Skip validation |
+| Only producer has contract | Warning (unless `fail-on-warning`) |
+| Only consumer has contract | Warning (unless `fail-on-warning`) |
+| Both have contracts | Validate compatibility |
+
+### Strict Mode
+
+When `strict = true`:
+
+- All components must declare schema contracts
+- Validation fails if any component lacks a contract
+- Useful for production pipelines where schema guarantees are required
+
+## Error Messages
+
+When validation fails, you get clear error messages:
+
+```
+Schema contract violation between 'ExtractSales' and 'TransformSales':
+  - Missing field 'customer_id' is missing from producer output
+    (field: customer_id, expected: string)
+  - Type mismatch for field 'amount'
+    (field: amount, expected: decimal(10,2), actual: double)
+```
+
+## Convenience Methods
+
+### SchemaDefinition.of
+
+Create schemas concisely using tuples:
+
+```scala
+val schema = SchemaDefinition.of(
+  ("user_id", "string", false),   // (name, type, nullable)
+  ("amount", "double", true)
+)
+```
+
+### SchemaField Constants
+
+Use predefined type constants:
+
+```scala
+import io.github.dwsmith1983.spark.pipeline.config.SchemaField.DataTypes._
+
+SchemaField("id", Long, nullable = false)
+SchemaField("name", String)
+SchemaField("created", Timestamp)
+```
+
+## Integration with Spark
+
+The `SparkSchemaConverter` utility converts between schema contracts and Spark's `StructType`:
+
+```scala
+import io.github.dwsmith1983.spark.pipeline.runtime.SparkSchemaConverter
+
+// Convert schema definition to Spark StructType
+val structType = SparkSchemaConverter.toStructType(schemaDefinition)
+
+// Convert Spark schema to schema definition
+val schemaDefinition = SparkSchemaConverter.fromStructType(df.schema)
+
+// Validate DataFrame against expected schema
+val errors = SparkSchemaConverter.validateAgainst(expectedSchema, df.schema)
+if (errors.nonEmpty) {
+  logger.error(s"Schema mismatch: ${errors.mkString(", ")}")
+}
+```
+
+## Best Practices
+
+### 1. Start with Output Contracts
+
+Begin by adding `outputContract` to components that produce data. This documents what the component guarantees to produce.
+
+### 2. Add Input Contracts Gradually
+
+Add `inputContract` to components that have specific requirements. This catches mismatches early.
+
+### 3. Use Strict Mode in Production
+
+Enable `strict = true` for production pipelines to ensure all components have explicit contracts.
+
+### 4. Keep Schemas Minimal
+
+Only declare fields that matter for validation. Extra fields in the producer output don't cause errors (just warnings).
+
+### 5. Document with Descriptions
+
+Add descriptions to schemas for documentation:
+
+```scala
+SchemaDefinition(
+  fields = Seq(SchemaField("user_id", "string")),
+  description = Some("User event data after deduplication")
+)
+```
+
+## Backward Compatibility
+
+Schema contracts are fully backward compatible:
+
+- Components without contracts continue to work unchanged
+- Validation is disabled by default
+- Existing pipelines require no changes
+
+To adopt schema contracts incrementally:
+
+1. Add `SchemaContract` trait to components one at a time
+2. Enable validation with `strict = false` initially
+3. Address warnings as they appear
+4. Enable `strict = true` when all components have contracts

--- a/website/docs/scope.md
+++ b/website/docs/scope.md
@@ -106,15 +106,17 @@ This framework is for **batch processing only**. It does not support:
 - Apache Flink
 - Apache Kafka Streams
 
-### Not a Schema Validation Framework
+### Optional Schema Contracts
 
-Components do not declare or validate their input/output schemas. There is:
+Components can optionally declare input/output schemas via the `SchemaContract` trait. When enabled:
 
-- No compile-time schema checking between components
-- No runtime schema validation
-- No automatic schema evolution handling
+- Runtime validation checks schema compatibility between adjacent components
+- Clear error messages when schemas don't match
+- Validation is disabled by default for backward compatibility
 
-**For schema validation**, combine with:
+See [Schema Contracts](./schema-contracts.md) for details.
+
+**For advanced data quality validation**, combine with:
 - Great Expectations
 - Deequ
 - Custom validation components
@@ -183,15 +185,17 @@ The framework runs a single pipeline to completion. It does not:
 
 The following features are planned for future versions:
 
+### v1.2.0 (Current)
+
+- **Schema contracts**: Optional input/output schema validation between components (see [Schema Contracts](./schema-contracts.md))
+
 ### v2.0 (Planned)
 
-- **Schema contracts**: Optional input/output schema validation between components
 - **Checkpointing**: Resume pipelines from last successful component
 - **Parallel execution**: DAG-based component execution (opt-in)
 
 ### Under Consideration
 
-- Structured Streaming support
 - Built-in data quality hooks
 - Spark UI integration
 - Circuit breaker patterns
@@ -214,6 +218,7 @@ Spark Pipeline Framework is the right choice when you need:
 - Simple, sequential batch pipelines
 - Configuration-driven architecture
 - Production-ready observability
+- Optional schema contracts between components
 - Minimal operational complexity
 
 It is **not** the right choice when you need:
@@ -221,6 +226,5 @@ It is **not** the right choice when you need:
 - Complex DAG workflows
 - Real-time streaming
 - Built-in scheduling
-- Schema validation between components
 
 The framework embraces the Unix philosophy: **do one thing well**. For sequential Spark batch pipelines with configuration-driven flexibility, it provides a clean, production-ready solution.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -7,6 +7,7 @@ const sidebars: SidebarsConfig = {
     'configuration',
     'config-validation',
     'secrets-management',
+    'schema-contracts',
     'components',
     'hooks',
     'streaming',


### PR DESCRIPTION
## Description

Add schema validation capability that allows pipeline components to declare their expected input/output schemas. When enabled, the runner validates schema compatibility between adjacent components before execution, catching mismatches early with clear error messages.

**Key features:**
- `SchemaContract` trait for optional input/output schema declarations
- `SchemaDefinition` and `SchemaField` types (platform-independent in core)
- `SparkSchemaConverter` for Spark StructType integration (in runtime)
- Configurable validation: `enabled`, `strict`, `fail-on-warning` options
- Validation disabled by default for backward compatibility

## Type of Change
- [x] `feat`: New feature

## Related Issues
Closes #49

## Checklist
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Tests added/updated for changes
- [x] `sbt scalafmtCheckAll` passes
- [x] `sbt test` passes
- [x] Documentation updated (if applicable)