### PR TITLE
feat: add checkpointing and resume for failed pipelines

### DIFF
--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointConfig.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointConfig.scala
@@ -1,0 +1,102 @@
+package io.github.dwsmith1983.spark.pipeline.checkpoint
+
+/**
+ * Configuration for pipeline checkpointing.
+ *
+ * Enables pipeline resume functionality by persisting component completion
+ * state to a configurable storage location.
+ *
+ * == HOCON Configuration ==
+ *
+ * {{{
+ * pipeline {
+ *   pipeline-name = "My Pipeline"
+ *
+ *   checkpoint {
+ *     enabled = true
+ *     location = "/tmp/spark-checkpoints"  # or s3://bucket/path
+ *     auto-resume = false
+ *     cleanup-on-success = true
+ *   }
+ *
+ *   pipeline-components = [...]
+ * }
+ * }}}
+ *
+ * == Configuration Options ==
+ *
+ *   - '''enabled''': Whether checkpointing is active (default: false)
+ *   - '''location''': Directory path for checkpoint storage (default: system temp)
+ *   - '''autoResume''': Automatically resume from last checkpoint on startup (default: false)
+ *   - '''cleanupOnSuccess''': Delete checkpoint after successful completion (default: true)
+ *
+ * @param enabled Whether checkpointing is enabled
+ * @param location Directory path for checkpoint storage
+ * @param autoResume Automatically resume from last failed checkpoint
+ * @param cleanupOnSuccess Delete checkpoint files after successful run
+ */
+case class CheckpointConfig(
+  enabled: Boolean = false,
+  location: String = FileSystemCheckpointStore.DefaultPath,
+  autoResume: Boolean = false,
+  cleanupOnSuccess: Boolean = true) {
+
+  /**
+   * Creates a checkpoint store based on this configuration.
+   *
+   * @return CheckpointStore instance configured per settings
+   */
+  def createStore(): CheckpointStore =
+    if (enabled) {
+      FileSystemCheckpointStore(location)
+    } else {
+      CheckpointStore.NoOp
+    }
+
+  /**
+   * Creates checkpoint hooks based on this configuration.
+   *
+   * @param runId Optional specific run ID
+   * @param resumedFrom Optional run ID being resumed from
+   * @return CheckpointHooks if enabled, NoOp PipelineHooks otherwise
+   */
+  def createHooks(
+    runId: Option[String] = None,
+    resumedFrom: Option[String] = None
+  ): CheckpointHooks = {
+    val store = createStore()
+    new CheckpointHooks(
+      store = store,
+      runId = runId.getOrElse(java.util.UUID.randomUUID().toString),
+      cleanupOnSuccess = cleanupOnSuccess,
+      resumedFrom = resumedFrom
+    )
+  }
+}
+
+object CheckpointConfig {
+
+  /** Default configuration with checkpointing disabled. */
+  val default: CheckpointConfig = CheckpointConfig()
+
+  /** Configuration with checkpointing enabled at default location. */
+  val enabled: CheckpointConfig = CheckpointConfig(enabled = true)
+
+  /**
+   * Creates configuration with checkpointing enabled at specified location.
+   *
+   * @param location Directory path for checkpoint storage
+   * @return CheckpointConfig with checkpointing enabled
+   */
+  def at(location: String): CheckpointConfig =
+    CheckpointConfig(enabled = true, location = location)
+
+  /**
+   * Creates configuration with auto-resume enabled.
+   *
+   * @param location Directory path for checkpoint storage
+   * @return CheckpointConfig with auto-resume enabled
+   */
+  def withAutoResume(location: String): CheckpointConfig =
+    CheckpointConfig(enabled = true, location = location, autoResume = true)
+}

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointHooks.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointHooks.scala
@@ -1,0 +1,258 @@
+package io.github.dwsmith1983.spark.pipeline.checkpoint
+
+import io.github.dwsmith1983.spark.pipeline.config._
+import org.apache.logging.log4j.{LogManager, Logger}
+
+import java.time.Instant
+import scala.collection.mutable
+
+/**
+ * Pipeline lifecycle hooks for checkpointing.
+ *
+ * Records component completion state to enable pipeline resume functionality.
+ * After each successful component, the checkpoint state is persisted to the
+ * configured store.
+ *
+ * == Basic Usage ==
+ *
+ * {{{
+ * val store = FileSystemCheckpointStore("/tmp/checkpoints")
+ * val hooks = CheckpointHooks(store)
+ *
+ * SimplePipelineRunner.run(config, hooks)
+ * }}}
+ *
+ * == With Other Hooks ==
+ *
+ * {{{
+ * val checkpointHooks = CheckpointHooks(store)
+ * val loggingHooks = LoggingHooks.structured()
+ *
+ * val combined = PipelineHooks.compose(checkpointHooks, loggingHooks)
+ * SimplePipelineRunner.run(config, combined)
+ * }}}
+ *
+ * @param store The checkpoint store for persistence
+ * @param runId Unique identifier for this run (auto-generated if not provided)
+ * @param cleanupOnSuccess Whether to delete checkpoint after successful completion
+ * @param resumedFrom Optional runId this run was resumed from
+ */
+class CheckpointHooks(
+  val store: CheckpointStore,
+  val runId: String = java.util.UUID.randomUUID().toString,
+  val cleanupOnSuccess: Boolean = true,
+  val resumedFrom: Option[String] = None)
+  extends PipelineHooks {
+
+  private val logger: Logger = LogManager.getLogger(getClass)
+
+  @volatile private var currentState: Option[CheckpointState] = None
+  @volatile private var pipelineStartTime: Instant            = _
+  private val componentStartTimes: mutable.Map[Int, Instant]  = mutable.Map()
+
+  override def beforePipeline(config: PipelineConfig): Unit = {
+    pipelineStartTime = Instant.now()
+
+    currentState = Some(
+      CheckpointState(
+        runId = runId,
+        pipelineName = config.pipelineName,
+        startedAt = pipelineStartTime,
+        completedComponents = List.empty,
+        lastCheckpointedIndex = -1,
+        totalComponents = config.pipelineComponents.size,
+        status = CheckpointStatus.Running,
+        resumedFrom = resumedFrom
+      )
+    )
+
+    try {
+      store.save(currentState.get)
+      logger.info(s"Checkpoint initialized for run: $runId")
+    } catch {
+      case e: CheckpointException =>
+        logger.warn(s"Failed to save initial checkpoint: ${e.getMessage}")
+    }
+  }
+
+  override def beforeComponent(config: ComponentConfig, index: Int, total: Int): Unit =
+    componentStartTimes(index) = Instant.now()
+
+  override def afterComponent(
+    config: ComponentConfig,
+    index: Int,
+    total: Int,
+    durationMs: Long
+  ): Unit = {
+    val startTime   = componentStartTimes.getOrElse(index, Instant.now().minusMillis(durationMs))
+    val completedAt = Instant.now()
+    locally { val _ = componentStartTimes.remove(index) }
+
+    val checkpoint = ComponentCheckpoint(
+      index = index,
+      name = config.instanceName,
+      instanceType = config.instanceType,
+      startedAt = startTime,
+      completedAt = completedAt,
+      durationMs = durationMs
+    )
+
+    currentState = currentState.map { state =>
+      state.copy(
+        completedComponents = state.completedComponents :+ checkpoint,
+        lastCheckpointedIndex = index
+      )
+    }
+
+    currentState.foreach { state =>
+      try {
+        store.save(state)
+        logger.debug(s"Checkpoint updated: component ${index + 1}/$total completed")
+      } catch {
+        case e: CheckpointException =>
+          logger.warn(s"Failed to save checkpoint after component $index: ${e.getMessage}")
+      }
+    }
+  }
+
+  override def onComponentFailure(config: ComponentConfig, index: Int, error: Throwable): Unit = {
+    locally { val _ = componentStartTimes.remove(index) }
+
+    val errorMessage = Option(error.getMessage).getOrElse(error.getClass.getSimpleName)
+
+    currentState = currentState.map(state => state.copy(status = CheckpointStatus.Failed(errorMessage, index)))
+
+    currentState.foreach { state =>
+      try {
+        store.save(state)
+        logger.info(s"Checkpoint saved after failure at component $index: $errorMessage")
+      } catch {
+        case e: CheckpointException =>
+          logger.warn(s"Failed to save checkpoint on failure: ${e.getMessage}")
+      }
+    }
+  }
+
+  override def afterPipeline(config: PipelineConfig, result: PipelineResult): Unit =
+    result match {
+      case PipelineResult.Success(_, _) =>
+        currentState = currentState.map(_.copy(status = CheckpointStatus.Completed))
+        currentState.foreach { state =>
+          if (cleanupOnSuccess) {
+            try {
+              store.delete(runId)
+              logger.info(s"Checkpoint cleaned up after successful run: $runId")
+            } catch {
+              case e: CheckpointException =>
+                logger.warn(s"Failed to delete checkpoint: ${e.getMessage}")
+            }
+          } else {
+            try {
+              store.save(state)
+            } catch {
+              case e: CheckpointException =>
+                logger.warn(s"Failed to save final checkpoint: ${e.getMessage}")
+            }
+          }
+        }
+
+      case PipelineResult.Failure(error, failedComponent, _) =>
+        // State should already be updated by onComponentFailure
+        // But ensure it's marked as failed
+        val errorMsg = Option(error.getMessage).getOrElse(error.getClass.getSimpleName)
+        val failedIdx = failedComponent
+          .flatMap(cc => config.pipelineComponents.zipWithIndex.find(_._1 == cc).map(_._2))
+          .getOrElse(-1)
+
+        currentState = currentState.map { state =>
+          if (state.status == CheckpointStatus.Running) {
+            state.copy(status = CheckpointStatus.Failed(errorMsg, failedIdx))
+          } else {
+            state
+          }
+        }
+
+        currentState.foreach { state =>
+          try {
+            store.save(state)
+            logger.info(s"Checkpoint finalized for failed run: $runId")
+          } catch {
+            case e: CheckpointException =>
+              logger.warn(s"Failed to save final checkpoint: ${e.getMessage}")
+          }
+        }
+
+      case PipelineResult.PartialSuccess(_, _, _, failures) =>
+        // Mark as failed with first failure info
+        val (failedConfig, error) = failures.head
+        val errorMsg              = Option(error.getMessage).getOrElse(error.getClass.getSimpleName)
+        val failedIdx             = config.pipelineComponents.indexOf(failedConfig)
+
+        currentState = currentState.map(state => state.copy(status = CheckpointStatus.Failed(errorMsg, failedIdx)))
+
+        currentState.foreach { state =>
+          try {
+            store.save(state)
+            logger.info(s"Checkpoint finalized for partial success: $runId")
+          } catch {
+            case e: CheckpointException =>
+              logger.warn(s"Failed to save final checkpoint: ${e.getMessage}")
+          }
+        }
+    }
+
+  /** Returns the current checkpoint state. */
+  def getState: Option[CheckpointState] = currentState
+}
+
+object CheckpointHooks {
+
+  /**
+   * Creates checkpoint hooks with a store.
+   *
+   * @param store The checkpoint store
+   * @return New CheckpointHooks instance
+   */
+  def apply(store: CheckpointStore): CheckpointHooks =
+    new CheckpointHooks(store)
+
+  /**
+   * Creates checkpoint hooks with full configuration.
+   *
+   * @param store The checkpoint store
+   * @param runId Unique run identifier
+   * @param cleanupOnSuccess Whether to delete checkpoint on success
+   * @param resumedFrom Optional runId being resumed from
+   * @return New CheckpointHooks instance
+   */
+  def apply(
+    store: CheckpointStore,
+    runId: String = java.util.UUID.randomUUID().toString,
+    cleanupOnSuccess: Boolean = true,
+    resumedFrom: Option[String] = None
+  ): CheckpointHooks =
+    new CheckpointHooks(store, runId, cleanupOnSuccess, resumedFrom)
+
+  /**
+   * Creates checkpoint hooks for resuming a failed run.
+   *
+   * @param store The checkpoint store
+   * @param originalRunId The runId of the failed run being resumed
+   * @return New CheckpointHooks configured for resume
+   */
+  def forResume(store: CheckpointStore, originalRunId: String): CheckpointHooks =
+    new CheckpointHooks(
+      store = store,
+      runId = java.util.UUID.randomUUID().toString,
+      cleanupOnSuccess = true,
+      resumedFrom = Some(originalRunId)
+    )
+
+  /**
+   * Creates checkpoint hooks using the default file system store.
+   *
+   * @return New CheckpointHooks with default FileSystemCheckpointStore
+   */
+  def withDefaultStore(): CheckpointHooks =
+    new CheckpointHooks(FileSystemCheckpointStore.default())
+}

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointSerializer.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointSerializer.scala
@@ -1,0 +1,232 @@
+package io.github.dwsmith1983.spark.pipeline.checkpoint
+
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import scala.util.{Failure, Success, Try}
+
+/**
+ * JSON serialization for checkpoint state.
+ *
+ * Uses manual serialization to avoid external dependencies and
+ * ensure compatibility across Scala 2.12/2.13.
+ */
+object CheckpointSerializer {
+
+  private val timestampFormatter: DateTimeFormatter = DateTimeFormatter.ISO_INSTANT
+
+  /**
+   * Serialize checkpoint state to JSON.
+   *
+   * @param state The checkpoint state to serialize
+   * @return JSON string representation
+   */
+  def toJson(state: CheckpointState): String = {
+    val sb = new StringBuilder
+    sb.append("{")
+    sb.append(s""""runId":"${escapeJson(state.runId)}",""")
+    sb.append(s""""pipelineName":"${escapeJson(state.pipelineName)}",""")
+    sb.append(s""""startedAt":"${timestampFormatter.format(state.startedAt)}",""")
+    sb.append(s""""completedComponents":${componentListToJson(state.completedComponents)},""")
+    sb.append(s""""lastCheckpointedIndex":${state.lastCheckpointedIndex},""")
+    sb.append(s""""totalComponents":${state.totalComponents},""")
+    sb.append(s""""status":${statusToJson(state.status)}""")
+    state.resumedFrom.foreach(r => sb.append(s""","resumedFrom":"${escapeJson(r)}""""))
+    sb.append("}")
+    sb.toString()
+  }
+
+  /**
+   * Deserialize checkpoint state from JSON.
+   *
+   * @param json The JSON string to parse
+   * @return Parsed checkpoint state
+   * @throws CheckpointException if parsing fails
+   */
+  def fromJson(json: String): CheckpointState =
+    Try {
+      val fields     = parseObject(json)
+      val runId      = fields("runId")
+      val pipeline   = fields("pipelineName")
+      val startedAt  = Instant.parse(fields("startedAt"))
+      val components = parseComponentList(fields("completedComponents"))
+      val lastIndex  = fields("lastCheckpointedIndex").toInt
+      val total      = fields("totalComponents").toInt
+      val status     = parseStatus(fields("status"))
+      val resumed    = fields.get("resumedFrom").filter(_.nonEmpty)
+
+      CheckpointState(runId, pipeline, startedAt, components, lastIndex, total, status, resumed)
+    } match {
+      case Success(state) => state
+      case Failure(e)     => throw CheckpointException.corruptedCheckpoint("unknown", e)
+    }
+
+  private def escapeJson(s: String): String =
+    if (s == null) {
+      ""
+    } else {
+      s.replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+        .replace("\b", "\\b")
+        .replace("\f", "\\f")
+    }
+
+  private def unescapeJson(s: String): String = {
+    // Use a placeholder for escaped backslashes to avoid interfering with other escape sequences
+    val placeholder = "\u0000BACKSLASH\u0000"
+    s.replace("\\\\", placeholder)
+      .replace("\\n", "\n")
+      .replace("\\r", "\r")
+      .replace("\\t", "\t")
+      .replace("\\b", "\b")
+      .replace("\\f", "\f")
+      .replace("\\\"", "\"")
+      .replace(placeholder, "\\")
+  }
+
+  private def componentToJson(c: ComponentCheckpoint): String = {
+    val sb = new StringBuilder
+    sb.append("{")
+    sb.append(s""""index":${c.index},""")
+    sb.append(s""""name":"${escapeJson(c.name)}",""")
+    sb.append(s""""instanceType":"${escapeJson(c.instanceType)}",""")
+    sb.append(s""""startedAt":"${timestampFormatter.format(c.startedAt)}",""")
+    sb.append(s""""completedAt":"${timestampFormatter.format(c.completedAt)}",""")
+    sb.append(s""""durationMs":${c.durationMs}""")
+    sb.append("}")
+    sb.toString()
+  }
+
+  private def componentListToJson(components: List[ComponentCheckpoint]): String =
+    components.map(componentToJson).mkString("[", ",", "]")
+
+  private def statusToJson(status: CheckpointStatus): String = status match {
+    case CheckpointStatus.Running =>
+      """{"type":"Running"}"""
+    case CheckpointStatus.Completed =>
+      """{"type":"Completed"}"""
+    case CheckpointStatus.Failed(msg, idx) =>
+      s"""{"type":"Failed","errorMessage":"${escapeJson(msg)}","failedIndex":$idx}"""
+  }
+
+  private def parseObject(json: String): Map[String, String] = {
+    val result = scala.collection.mutable.Map[String, String]()
+    var depth  = 0
+    var inKey  = false
+    var inVal  = false
+    var inStr  = false
+    var escape = false
+    val key    = new StringBuilder
+    val value  = new StringBuilder
+
+    for (c <- json.trim) {
+      if (escape) {
+        if (inKey) key.append(c)
+        else if (inVal) value.append(c)
+        escape = false
+      } else {
+        c match {
+          case '\\' =>
+            escape = true
+            if (inKey) key.append(c)
+            else if (inVal) value.append(c)
+          case '"' if depth == 1 && !inKey && !inVal =>
+            inKey = true
+          case '"' if depth == 1 && inKey && !inStr =>
+            inKey = false
+          case '"' if depth == 1 && inVal && !inStr =>
+            inStr = true
+            value.append(c)
+          case '"' if inStr =>
+            value.append(c)
+            inStr = false
+          case ':' if depth == 1 && !inKey && !inVal =>
+            inVal = true
+          case ',' if depth == 1 && !inStr =>
+            result(key.toString()) = cleanValue(value.toString())
+            key.clear()
+            value.clear()
+            inVal = false
+          case '{' | '[' =>
+            depth += 1
+            if (inVal) value.append(c)
+          case '}' | ']' =>
+            if (inVal && depth > 1) value.append(c)
+            depth -= 1
+            if (depth == 0 && key.nonEmpty) {
+              result(key.toString()) = cleanValue(value.toString())
+            }
+          case _ =>
+            if (inKey) key.append(c)
+            else if (inVal) value.append(c)
+        }
+      }
+    }
+    result.toMap
+  }
+
+  private def cleanValue(v: String): String = {
+    val trimmed = v.trim
+    if (trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
+      unescapeJson(trimmed.drop(1).dropRight(1))
+    } else {
+      trimmed
+    }
+  }
+
+  private def parseComponentList(json: String): List[ComponentCheckpoint] = {
+    if (json == "[]") return List.empty
+
+    val components = scala.collection.mutable.ListBuffer[ComponentCheckpoint]()
+    var depth      = 0
+    val current    = new StringBuilder
+
+    for (c <- json) {
+      c match {
+        case '[' if depth == 0 => depth += 1
+        case ']' if depth == 1 => depth -= 1
+        case '{' =>
+          depth += 1
+          current.append(c)
+        case '}' =>
+          current.append(c)
+          depth -= 1
+          if (depth == 1) {
+            components += parseComponent(current.toString())
+            current.clear()
+          }
+        case ',' if depth == 1 => // skip commas between objects
+        case _ if depth > 1    => current.append(c)
+        case _                 => // skip
+      }
+    }
+    components.toList
+  }
+
+  private def parseComponent(json: String): ComponentCheckpoint = {
+    val fields = parseObject(json)
+    ComponentCheckpoint(
+      index = fields("index").toInt,
+      name = fields("name"),
+      instanceType = fields("instanceType"),
+      startedAt = Instant.parse(fields("startedAt")),
+      completedAt = Instant.parse(fields("completedAt")),
+      durationMs = fields("durationMs").toLong
+    )
+  }
+
+  private def parseStatus(json: String): CheckpointStatus = {
+    val fields = parseObject(json)
+    fields("type") match {
+      case "Running"   => CheckpointStatus.Running
+      case "Completed" => CheckpointStatus.Completed
+      case "Failed" =>
+        CheckpointStatus.Failed(
+          fields("errorMessage"),
+          fields("failedIndex").toInt
+        )
+    }
+  }
+}

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointState.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointState.scala
@@ -1,0 +1,93 @@
+package io.github.dwsmith1983.spark.pipeline.checkpoint
+
+import java.time.Instant
+
+/**
+ * State model for pipeline checkpointing.
+ *
+ * Captures the execution state of a pipeline at a point in time, enabling
+ * resume functionality for failed pipelines.
+ *
+ * == Example ==
+ *
+ * {{{
+ * val state = CheckpointState(
+ *   runId = "abc123",
+ *   pipelineName = "my-etl-pipeline",
+ *   startedAt = Instant.now(),
+ *   completedComponents = List.empty,
+ *   lastCheckpointedIndex = -1,
+ *   totalComponents = 5,
+ *   status = CheckpointStatus.Running
+ * )
+ * }}}
+ *
+ * @param runId Unique identifier for this pipeline run
+ * @param pipelineName Name of the pipeline from configuration
+ * @param startedAt Timestamp when the pipeline started
+ * @param completedComponents List of successfully completed components
+ * @param lastCheckpointedIndex Index of last successful component (-1 if none)
+ * @param totalComponents Total number of components in the pipeline
+ * @param status Current status of the checkpoint (Running, Failed, Completed)
+ * @param resumedFrom Optional runId this run was resumed from
+ */
+case class CheckpointState(
+  runId: String,
+  pipelineName: String,
+  startedAt: Instant,
+  completedComponents: List[ComponentCheckpoint],
+  lastCheckpointedIndex: Int,
+  totalComponents: Int,
+  status: CheckpointStatus,
+  resumedFrom: Option[String] = None) {
+
+  /**
+   * Returns the index to start execution from when resuming.
+   * This is lastCheckpointedIndex + 1, or 0 if no components completed.
+   */
+  def resumeFromIndex: Int = lastCheckpointedIndex + 1
+
+  /** Returns true if this run can be resumed (has incomplete work). */
+  def canResume: Boolean = status match {
+    case CheckpointStatus.Failed(_, _) => lastCheckpointedIndex < totalComponents - 1
+    case _                             => false
+  }
+}
+
+/**
+ * Checkpoint state for a single completed component.
+ *
+ * @param index Zero-based index of the component in the pipeline
+ * @param name Instance name from configuration
+ * @param instanceType Fully qualified class name of the component
+ * @param startedAt When the component started execution
+ * @param completedAt When the component finished execution
+ * @param durationMs Execution time in milliseconds
+ */
+case class ComponentCheckpoint(
+  index: Int,
+  name: String,
+  instanceType: String,
+  startedAt: Instant,
+  completedAt: Instant,
+  durationMs: Long)
+
+/** Status of a checkpoint. */
+sealed trait CheckpointStatus
+
+object CheckpointStatus {
+
+  /** Pipeline is currently running. */
+  case object Running extends CheckpointStatus
+
+  /**
+   * Pipeline failed at a specific component.
+   *
+   * @param errorMessage Error message from the failure
+   * @param failedIndex Index of the component that failed
+   */
+  case class Failed(errorMessage: String, failedIndex: Int) extends CheckpointStatus
+
+  /** Pipeline completed successfully. */
+  case object Completed extends CheckpointStatus
+}

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointStore.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointStore.scala
@@ -1,0 +1,130 @@
+package io.github.dwsmith1983.spark.pipeline.checkpoint
+
+/**
+ * Storage interface for pipeline checkpoints.
+ *
+ * Implementations provide persistence for checkpoint state, enabling
+ * pipeline resume functionality across different storage backends.
+ *
+ * == Thread Safety ==
+ *
+ * Implementations should be thread-safe for concurrent reads but may
+ * assume single-writer semantics (only one pipeline run writes to a
+ * given checkpoint at a time).
+ *
+ * == Example ==
+ *
+ * {{{
+ * val store = FileSystemCheckpointStore("/tmp/checkpoints")
+ *
+ * // Save checkpoint
+ * store.save(checkpointState)
+ *
+ * // Load latest checkpoint for resume
+ * val checkpoint = store.loadLatest("my-pipeline")
+ *
+ * // Clean up after successful completion
+ * store.delete("run-123")
+ * }}}
+ */
+trait CheckpointStore {
+
+  /**
+   * Saves checkpoint state atomically.
+   *
+   * If a checkpoint with the same runId exists, it will be overwritten.
+   *
+   * @param state The checkpoint state to save
+   * @throws CheckpointException if the save operation fails
+   */
+  def save(state: CheckpointState): Unit
+
+  /**
+   * Loads the most recent incomplete checkpoint for a pipeline.
+   *
+   * Returns the checkpoint with the most recent startedAt timestamp
+   * that has a Failed status.
+   *
+   * @param pipelineName Name of the pipeline
+   * @return The most recent incomplete checkpoint, or None if not found
+   */
+  def loadLatest(pipelineName: String): Option[CheckpointState]
+
+  /**
+   * Loads a checkpoint by its specific run ID.
+   *
+   * @param runId The run ID to load
+   * @return The checkpoint state, or None if not found
+   */
+  def loadByRunId(runId: String): Option[CheckpointState]
+
+  /**
+   * Deletes a checkpoint by run ID.
+   *
+   * Used to clean up after successful pipeline completion.
+   *
+   * @param runId The run ID to delete
+   */
+  def delete(runId: String): Unit
+
+  /**
+   * Lists all incomplete (failed) checkpoints.
+   *
+   * @return List of all checkpoints with Failed status
+   */
+  def listIncomplete(): List[CheckpointState]
+
+  /**
+   * Lists all incomplete checkpoints for a specific pipeline.
+   *
+   * @param pipelineName Name of the pipeline
+   * @return List of incomplete checkpoints for the pipeline
+   */
+  def listIncomplete(pipelineName: String): List[CheckpointState]
+}
+
+object CheckpointStore {
+
+  /**
+   * A no-op checkpoint store that doesn't persist anything.
+   *
+   * Useful for testing or when checkpointing is disabled.
+   */
+  val NoOp: CheckpointStore = new CheckpointStore {
+    override def save(state: CheckpointState): Unit                          = ()
+    override def loadLatest(pipelineName: String): Option[CheckpointState]   = None
+    override def loadByRunId(runId: String): Option[CheckpointState]         = None
+    override def delete(runId: String): Unit                                 = ()
+    override def listIncomplete(): List[CheckpointState]                     = List.empty
+    override def listIncomplete(pipelineName: String): List[CheckpointState] = List.empty
+  }
+}
+
+/**
+ * Exception thrown when checkpoint operations fail.
+ *
+ * @param message Description of the failure
+ * @param cause Underlying cause, if any
+ */
+class CheckpointException(message: String, cause: Throwable = null) extends RuntimeException(message, cause)
+
+object CheckpointException {
+
+  def saveFailure(runId: String, cause: Throwable): CheckpointException =
+    new CheckpointException(s"Failed to save checkpoint for run: $runId", cause)
+
+  def loadFailure(runId: String, cause: Throwable): CheckpointException =
+    new CheckpointException(s"Failed to load checkpoint for run: $runId", cause)
+
+  def deleteFailure(runId: String, cause: Throwable): CheckpointException =
+    new CheckpointException(s"Failed to delete checkpoint for run: $runId", cause)
+
+  def corruptedCheckpoint(runId: String, cause: Throwable): CheckpointException =
+    new CheckpointException(s"Checkpoint data corrupted for run: $runId", cause)
+
+  def configMismatch(expectedComponents: Int, actualComponents: Int): CheckpointException =
+    new CheckpointException(
+      s"Pipeline configuration mismatch: checkpoint has $expectedComponents components, " +
+        s"current config has $actualComponents components. Cannot safely resume."
+    )
+}

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/FileSystemCheckpointStore.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/FileSystemCheckpointStore.scala
@@ -1,0 +1,224 @@
+package io.github.dwsmith1983.spark.pipeline.checkpoint
+
+import org.apache.logging.log4j.{LogManager, Logger}
+
+import java.io._
+import java.nio.charset.StandardCharsets
+import java.nio.file._
+import java.util.stream.{Stream => JStream}
+import scala.util.{Failure, Success, Try}
+
+/**
+ * File system-based checkpoint store.
+ *
+ * Stores checkpoints as JSON files in the specified base directory.
+ * Uses atomic file operations (write to temp file, then rename) to
+ * ensure consistency.
+ *
+ * == Directory Structure ==
+ *
+ * {{{
+ * basePath/
+ *   pipeline-name-1/
+ *     run-id-1.json
+ *     run-id-2.json
+ *   pipeline-name-2/
+ *     run-id-3.json
+ * }}}
+ *
+ * == Example ==
+ *
+ * {{{
+ * val store = FileSystemCheckpointStore("/tmp/spark-checkpoints")
+ * store.save(checkpointState)
+ * val state = store.loadLatest("my-pipeline")
+ * }}}
+ *
+ * @param basePath Base directory for checkpoint storage
+ */
+class FileSystemCheckpointStore(basePath: String) extends CheckpointStore {
+
+  private val logger: Logger = LogManager.getLogger(getClass)
+  private val baseDir: Path  = Paths.get(basePath)
+  private val jsonExtension  = ".json"
+
+  // Ensure base directory exists
+  Try(Files.createDirectories(baseDir)) match {
+    case Success(_) =>
+      logger.debug(s"Checkpoint store initialized at: $basePath")
+    case Failure(e) =>
+      logger.error(s"Failed to create checkpoint directory: $basePath", e)
+      throw new CheckpointException(s"Cannot create checkpoint directory: $basePath", e)
+  }
+
+  override def save(state: CheckpointState): Unit = {
+    val pipelineDir = baseDir.resolve(sanitizeName(state.pipelineName))
+    val targetFile  = pipelineDir.resolve(state.runId + jsonExtension)
+    val tempFile    = pipelineDir.resolve(s".${state.runId}.tmp")
+
+    try {
+      Files.createDirectories(pipelineDir)
+
+      // Write to temp file first
+      val json = CheckpointSerializer.toJson(state)
+      Files.write(tempFile, json.getBytes(StandardCharsets.UTF_8))
+
+      // Atomic rename
+      Files.move(tempFile, targetFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+
+      logger.debug(s"Checkpoint saved: ${state.runId} at ${targetFile.toAbsolutePath}")
+    } catch {
+      case e: IOException =>
+        // Clean up temp file if it exists
+        Try(Files.deleteIfExists(tempFile))
+        throw CheckpointException.saveFailure(state.runId, e)
+    }
+  }
+
+  override def loadLatest(pipelineName: String): Option[CheckpointState] = {
+    val pipelineDir = baseDir.resolve(sanitizeName(pipelineName))
+
+    if (!Files.exists(pipelineDir)) {
+      return None
+    }
+
+    try {
+      val checkpoints = listJsonFiles(pipelineDir)
+        .flatMap(p => loadFromPath(p).toOption)
+        .filter(_.status.isInstanceOf[CheckpointStatus.Failed])
+
+      // Return the most recent by startedAt
+      checkpoints.sortBy(_.startedAt)(Ordering[java.time.Instant].reverse).headOption
+    } catch {
+      case e: IOException =>
+        logger.warn(s"Error listing checkpoints for pipeline: $pipelineName", e)
+        None
+    }
+  }
+
+  override def loadByRunId(runId: String): Option[CheckpointState] =
+    // Search all pipeline directories for the runId
+    try {
+      listDirectories(baseDir)
+        .map(_.resolve(runId + jsonExtension))
+        .find(Files.exists(_))
+        .flatMap(loadFromPath(_).toOption)
+    } catch {
+      case e: IOException =>
+        logger.warn(s"Error searching for checkpoint: $runId", e)
+        None
+    }
+
+  override def delete(runId: String): Unit =
+    try {
+      // Find and delete the checkpoint file
+      listDirectories(baseDir)
+        .map(_.resolve(runId + jsonExtension))
+        .filter(Files.exists(_))
+        .foreach { path =>
+          Files.delete(path)
+          logger.debug(s"Checkpoint deleted: $runId")
+        }
+    } catch {
+      case e: IOException =>
+        throw CheckpointException.deleteFailure(runId, e)
+    }
+
+  override def listIncomplete(): List[CheckpointState] =
+    try {
+      listDirectories(baseDir)
+        .flatMap { pipelineDir =>
+          listJsonFiles(pipelineDir)
+            .flatMap(loadFromPath(_).toOption)
+            .filter(_.status.isInstanceOf[CheckpointStatus.Failed])
+        }
+        .sortBy(_.startedAt)(Ordering[java.time.Instant].reverse)
+    } catch {
+      case e: IOException =>
+        logger.warn("Error listing incomplete checkpoints", e)
+        List.empty
+    }
+
+  override def listIncomplete(pipelineName: String): List[CheckpointState] = {
+    val pipelineDir = baseDir.resolve(sanitizeName(pipelineName))
+
+    if (!Files.exists(pipelineDir)) {
+      return List.empty
+    }
+
+    try {
+      listJsonFiles(pipelineDir)
+        .flatMap(loadFromPath(_).toOption)
+        .filter(_.status.isInstanceOf[CheckpointStatus.Failed])
+        .sortBy(_.startedAt)(Ordering[java.time.Instant].reverse)
+    } catch {
+      case e: IOException =>
+        logger.warn(s"Error listing incomplete checkpoints for: $pipelineName", e)
+        List.empty
+    }
+  }
+
+  private def loadFromPath(path: Path): Try[CheckpointState] =
+    Try {
+      val json = new String(Files.readAllBytes(path), StandardCharsets.UTF_8)
+      CheckpointSerializer.fromJson(json)
+    }
+
+  /** Lists all subdirectories of the given directory. */
+  private def listDirectories(dir: Path): List[Path] =
+    withStream(Files.list(dir))(stream => streamToList(stream).filter(Files.isDirectory(_)))
+
+  /** Lists all JSON files in the given directory (excluding hidden files). */
+  private def listJsonFiles(dir: Path): List[Path] =
+    withStream(Files.list(dir)) { stream =>
+      streamToList(stream).filter { p =>
+        val name = p.getFileName.toString
+        name.endsWith(jsonExtension) && !name.startsWith(".")
+      }
+    }
+
+  /** Converts a Java Stream to a Scala List, ensuring the stream is closed. */
+  private def withStream[T, R](stream: JStream[T])(f: JStream[T] => R): R =
+    try {
+      f(stream)
+    } finally {
+      stream.close()
+    }
+
+  /** Converts a Java Stream to a Scala List. */
+  private def streamToList[T](stream: JStream[T]): List[T] = {
+    val builder = List.newBuilder[T]
+    stream.forEach(item => builder += item)
+    builder.result()
+  }
+
+  /**
+   * Sanitize pipeline name for use as directory name.
+   * Replaces problematic characters with underscores.
+   */
+  private def sanitizeName(name: String): String =
+    name.replaceAll("[^a-zA-Z0-9._-]", "_")
+}
+
+object FileSystemCheckpointStore {
+
+  /**
+   * Creates a checkpoint store at the specified path.
+   *
+   * @param basePath Base directory for checkpoint storage
+   * @return New FileSystemCheckpointStore instance
+   */
+  def apply(basePath: String): FileSystemCheckpointStore =
+    new FileSystemCheckpointStore(basePath)
+
+  /** Default checkpoint location in the system temp directory. */
+  val DefaultPath: String = System.getProperty("java.io.tmpdir") + "/spark-pipeline-checkpoints"
+
+  /**
+   * Creates a checkpoint store at the default location.
+   *
+   * @return New FileSystemCheckpointStore at default path
+   */
+  def default(): FileSystemCheckpointStore =
+    new FileSystemCheckpointStore(DefaultPath)
+}

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/ConfigModels.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/ConfigModels.scala
@@ -1,6 +1,7 @@
 package io.github.dwsmith1983.spark.pipeline.config
 
 import com.typesafe.config.Config
+import io.github.dwsmith1983.spark.pipeline.checkpoint.CheckpointConfig
 
 /**
  * Configuration models for the pipeline framework.
@@ -20,6 +21,15 @@ import com.typesafe.config.Config
  *     strict = false
  *     fail-on-warning = false
  *   }
+ *
+ *   # Optional checkpoint configuration for resume support
+ *   checkpoint {
+ *     enabled = true
+ *     location = "/tmp/spark-checkpoints"
+ *     auto-resume = false
+ *     cleanup-on-success = true
+ *   }
+ *
  *   pipeline-components = [...]
  * }
  * }}}
@@ -30,12 +40,14 @@ import com.typesafe.config.Config
  *                 If false, continue executing remaining components and report all failures.
  * @param schemaValidation Optional schema validation configuration. When enabled,
  *                         the runner validates schema contracts between adjacent components.
+ * @param checkpoint Optional checkpoint configuration for resume functionality
  */
 case class PipelineConfig(
   pipelineName: String,
   pipelineComponents: List[ComponentConfig],
   failFast: Boolean = true,
-  schemaValidation: Option[SchemaValidationConfig] = None)
+  schemaValidation: Option[SchemaValidationConfig] = None,
+  checkpoint: Option[CheckpointConfig] = None)
 
 /**
  * Configuration for a single pipeline component.

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/SchemaContract.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/config/SchemaContract.scala
@@ -126,8 +126,9 @@ object SchemaDefinition {
    * }}}
    */
   def of(fields: (String, String, Boolean)*): SchemaDefinition =
-    SchemaDefinition(fields.map { case (name, dataType, nullable) =>
-      SchemaField(name, dataType, nullable)
+    SchemaDefinition(fields.map {
+      case (name, dataType, nullable) =>
+        SchemaField(name, dataType, nullable)
     })
 }
 
@@ -195,9 +196,7 @@ object SchemaValidationConfig {
     SchemaValidationConfig(enabled = true, strict = true, failOnWarning = true)
 }
 
-/**
- * Result of schema validation between two components.
- */
+/** Result of schema validation between two components. */
 sealed trait SchemaValidationResult {
 
   /** Whether the validation passed without errors. */
@@ -223,7 +222,7 @@ object SchemaValidationResult {
   final case class Valid(warnings: List[SchemaValidationWarning] = List.empty)
     extends SchemaValidationResult {
 
-    override def isValid: Boolean                         = true
+    override def isValid: Boolean                    = true
     override def errors: List[SchemaValidationError] = List.empty
   }
 
@@ -243,8 +242,8 @@ object SchemaValidationResult {
 
   /** Validation skipped because contracts were not declared. */
   case object Skipped extends SchemaValidationResult {
-    override def isValid: Boolean                           = true
-    override def errors: List[SchemaValidationError]   = List.empty
+    override def isValid: Boolean                        = true
+    override def errors: List[SchemaValidationError]     = List.empty
     override def warnings: List[SchemaValidationWarning] = List.empty
   }
 
@@ -350,9 +349,7 @@ object SchemaWarningType {
   }
 }
 
-/**
- * Validates schema compatibility between adjacent components.
- */
+/** Validates schema compatibility between adjacent components. */
 object SchemaValidator {
 
   /**

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/dq/DataQualitySink.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/dq/DataQualitySink.scala
@@ -170,29 +170,33 @@ object DataQualityResultSerializer {
 
     case DataQualityResult.Failed(checkName, tableName, message, details, timestamp) =>
       s"""{"status":"failed","check_name":"$checkName","table_name":"$tableName","message":"${escapeJson(
-          message)}","timestamp":"${timestampFormatter.format(timestamp)}","details":${mapToJson(details)}}"""
+          message
+        )}","timestamp":"${timestampFormatter.format(timestamp)}","details":${mapToJson(details)}}"""
 
     case DataQualityResult.Warning(checkName, tableName, message, details, timestamp) =>
       s"""{"status":"warning","check_name":"$checkName","table_name":"$tableName","message":"${escapeJson(
-          message)}","timestamp":"${timestampFormatter.format(timestamp)}","details":${mapToJson(details)}}"""
+          message
+        )}","timestamp":"${timestampFormatter.format(timestamp)}","details":${mapToJson(details)}}"""
 
     case DataQualityResult.Skipped(checkName, tableName, reason, timestamp) =>
       s"""{"status":"skipped","check_name":"$checkName","table_name":"$tableName","reason":"${escapeJson(
-          reason)}","timestamp":"${timestampFormatter.format(timestamp)}"}"""
+          reason
+        )}","timestamp":"${timestampFormatter.format(timestamp)}"}"""
   }
 
   private def mapToJson(map: Map[String, Any]): String =
     if (map.isEmpty) "{}"
     else {
-      val entries = map.map { case (k, v) =>
-        val valueJson = v match {
-          case s: String  => s""""${escapeJson(s)}""""
-          case n: Number  => n.toString
-          case b: Boolean => b.toString
-          case null       => "null"
-          case other      => s""""${escapeJson(other.toString)}""""
-        }
-        s""""$k":$valueJson"""
+      val entries = map.map {
+        case (k, v) =>
+          val valueJson = v match {
+            case s: String  => s""""${escapeJson(s)}""""
+            case n: Number  => n.toString
+            case b: Boolean => b.toString
+            case null       => "null"
+            case other      => s""""${escapeJson(other.toString)}""""
+          }
+          s""""$k":$valueJson"""
       }
       s"{${entries.mkString(",")}}"
     }

--- a/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointConfigSpec.scala
+++ b/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointConfigSpec.scala
@@ -1,0 +1,109 @@
+package io.github.dwsmith1983.spark.pipeline.checkpoint
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+/** Tests for CheckpointConfig. */
+class CheckpointConfigSpec extends AnyFunSpec with Matchers {
+
+  describe("CheckpointConfig") {
+
+    describe("defaults") {
+
+      it("should have checkpointing disabled by default") {
+        val config = CheckpointConfig()
+        config.enabled shouldBe false
+      }
+
+      it("should use default location") {
+        val config = CheckpointConfig()
+        config.location shouldBe FileSystemCheckpointStore.DefaultPath
+      }
+
+      it("should have autoResume disabled by default") {
+        val config = CheckpointConfig()
+        config.autoResume shouldBe false
+      }
+
+      it("should have cleanupOnSuccess enabled by default") {
+        val config = CheckpointConfig()
+        config.cleanupOnSuccess shouldBe true
+      }
+    }
+
+    describe("createStore") {
+
+      it("should create FileSystemCheckpointStore when enabled") {
+        val config = CheckpointConfig(enabled = true, location = "/tmp/test-checkpoints")
+        val store  = config.createStore()
+
+        store shouldBe a[FileSystemCheckpointStore]
+      }
+
+      it("should return NoOp store when disabled") {
+        val config = CheckpointConfig(enabled = false)
+        val store  = config.createStore()
+
+        store shouldBe CheckpointStore.NoOp
+      }
+    }
+
+    describe("createHooks") {
+
+      it("should create CheckpointHooks with config settings") {
+        val config = CheckpointConfig(enabled = true, cleanupOnSuccess = false)
+        val hooks  = config.createHooks()
+
+        hooks.cleanupOnSuccess shouldBe false
+      }
+
+      it("should use provided runId") {
+        val config = CheckpointConfig(enabled = true)
+        val hooks  = config.createHooks(runId = Some("custom-run-id"))
+
+        hooks.runId shouldBe "custom-run-id"
+      }
+
+      it("should track resumedFrom") {
+        val config = CheckpointConfig(enabled = true)
+        val hooks  = config.createHooks(resumedFrom = Some("original-run"))
+
+        hooks.resumedFrom shouldBe Some("original-run")
+      }
+
+      it("should generate runId when not provided") {
+        val config = CheckpointConfig(enabled = true)
+        val hooks  = config.createHooks()
+
+        hooks.runId should not be empty
+        (hooks.runId should have).length(36) // UUID format
+      }
+    }
+  }
+
+  describe("CheckpointConfig factory methods") {
+
+    it("should create default config") {
+      val config = CheckpointConfig.default
+      config.enabled shouldBe false
+    }
+
+    it("should create enabled config") {
+      val config = CheckpointConfig.enabled
+      config.enabled shouldBe true
+    }
+
+    it("should create config at specific location") {
+      val config = CheckpointConfig.at("/custom/path")
+      config.enabled shouldBe true
+      config.location shouldBe "/custom/path"
+    }
+
+    it("should create config with auto-resume") {
+      val config = CheckpointConfig.withAutoResume("/auto/resume/path")
+      config.enabled shouldBe true
+      config.autoResume shouldBe true
+      config.location shouldBe "/auto/resume/path"
+    }
+  }
+}

--- a/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointHooksSpec.scala
+++ b/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointHooksSpec.scala
@@ -1,0 +1,303 @@
+package io.github.dwsmith1983.spark.pipeline.checkpoint
+
+import com.typesafe.config.ConfigFactory
+import io.github.dwsmith1983.spark.pipeline.config._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
+
+import scala.collection.mutable.ListBuffer
+
+/** In-memory checkpoint store for testing. */
+class TestCheckpointStore extends CheckpointStore {
+  val saved: ListBuffer[CheckpointState] = ListBuffer.empty
+  val deleted: ListBuffer[String]        = ListBuffer.empty
+  var saveCount: Int                     = 0
+
+  override def save(state: CheckpointState): Unit = {
+    saveCount += 1
+    // Remove old version if exists (Scala 2.12 compatible)
+    val toRemove = saved.filter(_.runId == state.runId)
+    saved --= toRemove
+    saved += state
+  }
+
+  override def loadLatest(pipelineName: String): Option[CheckpointState] =
+    saved
+      .filter(s => s.pipelineName == pipelineName && s.status.isInstanceOf[CheckpointStatus.Failed])
+      .sortBy(_.startedAt)(Ordering[java.time.Instant].reverse)
+      .headOption
+
+  override def loadByRunId(runId: String): Option[CheckpointState] =
+    saved.find(_.runId == runId)
+
+  override def delete(runId: String): Unit = {
+    deleted += runId
+    // Scala 2.12 compatible removal
+    val toRemove = saved.filter(_.runId == runId)
+    saved --= toRemove
+  }
+
+  override def listIncomplete(): List[CheckpointState] =
+    saved.filter(_.status.isInstanceOf[CheckpointStatus.Failed]).toList
+
+  override def listIncomplete(pipelineName: String): List[CheckpointState] =
+    saved.filter(s => s.pipelineName == pipelineName && s.status.isInstanceOf[CheckpointStatus.Failed]).toList
+
+  def clear(): Unit = {
+    saved.clear()
+    deleted.clear()
+    saveCount = 0
+  }
+
+  def latestState: Option[CheckpointState] = saved.lastOption
+}
+
+/** Tests for CheckpointHooks. */
+class CheckpointHooksSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach {
+
+  var store: TestCheckpointStore = _
+  var hooks: CheckpointHooks     = _
+
+  val testPipelineConfig: PipelineConfig = PipelineConfig(
+    pipelineName = "Test Pipeline",
+    pipelineComponents = List(
+      ComponentConfig(
+        instanceType = "com.example.Component1",
+        instanceName = "Component1",
+        instanceConfig = ConfigFactory.empty()
+      ),
+      ComponentConfig(
+        instanceType = "com.example.Component2",
+        instanceName = "Component2",
+        instanceConfig = ConfigFactory.empty()
+      ),
+      ComponentConfig(
+        instanceType = "com.example.Component3",
+        instanceName = "Component3",
+        instanceConfig = ConfigFactory.empty()
+      )
+    )
+  )
+
+  override def beforeEach(): Unit = {
+    store = new TestCheckpointStore()
+    hooks = new CheckpointHooks(store, runId = "test-run-123")
+  }
+
+  describe("CheckpointHooks") {
+
+    describe("beforePipeline") {
+
+      it("should initialize checkpoint state") {
+        hooks.beforePipeline(testPipelineConfig)
+
+        store.latestState shouldBe defined
+        val state = store.latestState.get
+        state.runId shouldBe "test-run-123"
+        state.pipelineName shouldBe "Test Pipeline"
+        state.totalComponents shouldBe 3
+        state.lastCheckpointedIndex shouldBe -1
+        state.status shouldBe CheckpointStatus.Running
+      }
+
+      it("should save initial checkpoint to store") {
+        hooks.beforePipeline(testPipelineConfig)
+
+        (store.saved should have).length(1)
+      }
+    }
+
+    describe("afterComponent") {
+
+      it("should update checkpoint after each component") {
+        hooks.beforePipeline(testPipelineConfig)
+        hooks.beforeComponent(testPipelineConfig.pipelineComponents.head, 0, 3)
+        hooks.afterComponent(testPipelineConfig.pipelineComponents.head, 0, 3, 100L)
+
+        val state = store.latestState.get
+        state.lastCheckpointedIndex shouldBe 0
+        (state.completedComponents should have).length(1)
+      }
+
+      it("should accumulate completed components") {
+        hooks.beforePipeline(testPipelineConfig)
+
+        testPipelineConfig.pipelineComponents.zipWithIndex.foreach {
+          case (comp, idx) =>
+            hooks.beforeComponent(comp, idx, 3)
+            hooks.afterComponent(comp, idx, 3, 100L)
+        }
+
+        val state = store.latestState.get
+        state.lastCheckpointedIndex shouldBe 2
+        (state.completedComponents should have).length(3)
+      }
+
+      it("should record component details") {
+        hooks.beforePipeline(testPipelineConfig)
+        hooks.beforeComponent(testPipelineConfig.pipelineComponents.head, 0, 3)
+        hooks.afterComponent(testPipelineConfig.pipelineComponents.head, 0, 3, 150L)
+
+        val checkpoint = store.latestState.get.completedComponents.head
+        checkpoint.index shouldBe 0
+        checkpoint.name shouldBe "Component1"
+        checkpoint.instanceType shouldBe "com.example.Component1"
+        checkpoint.durationMs shouldBe 150L
+      }
+
+      it("should save to store after each component") {
+        hooks.beforePipeline(testPipelineConfig)
+        val initialSaveCount = store.saveCount
+
+        hooks.beforeComponent(testPipelineConfig.pipelineComponents.head, 0, 3)
+        hooks.afterComponent(testPipelineConfig.pipelineComponents.head, 0, 3, 100L)
+
+        store.saveCount shouldBe (initialSaveCount + 1)
+
+        hooks.beforeComponent(testPipelineConfig.pipelineComponents(1), 1, 3)
+        hooks.afterComponent(testPipelineConfig.pipelineComponents(1), 1, 3, 100L)
+
+        store.saveCount shouldBe (initialSaveCount + 2)
+      }
+    }
+
+    describe("onComponentFailure") {
+
+      it("should update status to Failed") {
+        hooks.beforePipeline(testPipelineConfig)
+        hooks.beforeComponent(testPipelineConfig.pipelineComponents.head, 0, 3)
+        hooks.onComponentFailure(testPipelineConfig.pipelineComponents.head, 0, new RuntimeException("Test error"))
+
+        val state = store.latestState.get
+        state.status shouldBe a[CheckpointStatus.Failed]
+        state.status.asInstanceOf[CheckpointStatus.Failed].errorMessage shouldBe "Test error"
+        state.status.asInstanceOf[CheckpointStatus.Failed].failedIndex shouldBe 0
+      }
+
+      it("should save failed state to store") {
+        hooks.beforePipeline(testPipelineConfig)
+        store.saved.clear()
+
+        hooks.beforeComponent(testPipelineConfig.pipelineComponents.head, 0, 3)
+        hooks.onComponentFailure(testPipelineConfig.pipelineComponents.head, 0, new RuntimeException("Error"))
+
+        (store.saved should have).length(1)
+        store.latestState.get.status shouldBe a[CheckpointStatus.Failed]
+      }
+
+      it("should handle null error message") {
+        hooks.beforePipeline(testPipelineConfig)
+        hooks.beforeComponent(testPipelineConfig.pipelineComponents.head, 0, 3)
+        hooks.onComponentFailure(testPipelineConfig.pipelineComponents.head, 0, new RuntimeException(null: String))
+
+        val state = store.latestState.get
+        state.status.asInstanceOf[CheckpointStatus.Failed].errorMessage shouldBe "RuntimeException"
+      }
+    }
+
+    describe("afterPipeline") {
+
+      describe("on success") {
+
+        it("should delete checkpoint when cleanupOnSuccess is true") {
+          val cleanupHooks = new CheckpointHooks(store, runId = "cleanup-run", cleanupOnSuccess = true)
+
+          cleanupHooks.beforePipeline(testPipelineConfig)
+          cleanupHooks.afterPipeline(testPipelineConfig, PipelineResult.Success(100L, 3))
+
+          store.deleted should contain("cleanup-run")
+        }
+
+        it("should keep checkpoint when cleanupOnSuccess is false") {
+          val keepHooks = new CheckpointHooks(store, runId = "keep-run", cleanupOnSuccess = false)
+
+          keepHooks.beforePipeline(testPipelineConfig)
+          keepHooks.afterPipeline(testPipelineConfig, PipelineResult.Success(100L, 3))
+
+          store.deleted should not contain "keep-run"
+          store.latestState.get.status shouldBe CheckpointStatus.Completed
+        }
+      }
+
+      describe("on failure") {
+
+        it("should keep checkpoint for resume") {
+          hooks.beforePipeline(testPipelineConfig)
+          hooks.beforeComponent(testPipelineConfig.pipelineComponents.head, 0, 3)
+          hooks.onComponentFailure(testPipelineConfig.pipelineComponents.head, 0, new RuntimeException("Error"))
+          hooks.afterPipeline(
+            testPipelineConfig,
+            PipelineResult.Failure(
+              new RuntimeException("Error"),
+              Some(testPipelineConfig.pipelineComponents.head),
+              0
+            )
+          )
+
+          store.deleted shouldBe empty
+          store.latestState shouldBe defined
+        }
+      }
+
+      describe("on partial success") {
+
+        it("should mark as failed with first failure info") {
+          hooks.beforePipeline(testPipelineConfig)
+          hooks.afterPipeline(
+            testPipelineConfig,
+            PipelineResult.PartialSuccess(
+              200L,
+              2,
+              1,
+              List((testPipelineConfig.pipelineComponents(2), new RuntimeException("Partial error")))
+            )
+          )
+
+          val state = store.latestState.get
+          state.status shouldBe a[CheckpointStatus.Failed]
+        }
+      }
+    }
+
+    describe("getState") {
+
+      it("should return current state") {
+        hooks.beforePipeline(testPipelineConfig)
+
+        val state = hooks.getState
+        state shouldBe defined
+        state.get.runId shouldBe "test-run-123"
+      }
+
+      it("should return None before beforePipeline") {
+        hooks.getState shouldBe None
+      }
+    }
+
+    describe("resumedFrom tracking") {
+
+      it("should track original run when resuming") {
+        val resumeHooks = CheckpointHooks.forResume(store, "original-run")
+
+        resumeHooks.beforePipeline(testPipelineConfig)
+
+        val state = store.latestState.get
+        state.resumedFrom shouldBe Some("original-run")
+      }
+    }
+  }
+
+  describe("CheckpointHooks factory methods") {
+
+    it("should create hooks with store") {
+      val h = CheckpointHooks(store)
+      h.store shouldBe store
+    }
+
+    it("should create hooks for resume") {
+      val h = CheckpointHooks.forResume(store, "original-123")
+      h.resumedFrom shouldBe Some("original-123")
+    }
+  }
+}

--- a/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointSerializerSpec.scala
+++ b/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointSerializerSpec.scala
@@ -1,0 +1,223 @@
+package io.github.dwsmith1983.spark.pipeline.checkpoint
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+
+/** Tests for CheckpointSerializer JSON serialization. */
+class CheckpointSerializerSpec extends AnyFunSpec with Matchers {
+
+  val testInstant: Instant = Instant.parse("2024-01-15T10:30:00Z")
+
+  describe("CheckpointSerializer") {
+
+    describe("toJson/fromJson round-trip") {
+
+      it("should serialize and deserialize Running state") {
+        val state = CheckpointState(
+          runId = "run-123",
+          pipelineName = "test-pipeline",
+          startedAt = testInstant,
+          completedComponents = List.empty,
+          lastCheckpointedIndex = -1,
+          totalComponents = 5,
+          status = CheckpointStatus.Running
+        )
+
+        val json     = CheckpointSerializer.toJson(state)
+        val restored = CheckpointSerializer.fromJson(json)
+
+        restored shouldBe state
+      }
+
+      it("should serialize and deserialize Failed state") {
+        val state = CheckpointState(
+          runId = "run-456",
+          pipelineName = "my-etl-pipeline",
+          startedAt = testInstant,
+          completedComponents = List.empty,
+          lastCheckpointedIndex = 2,
+          totalComponents = 5,
+          status = CheckpointStatus.Failed("Connection timeout", 3)
+        )
+
+        val json     = CheckpointSerializer.toJson(state)
+        val restored = CheckpointSerializer.fromJson(json)
+
+        restored shouldBe state
+      }
+
+      it("should serialize and deserialize Completed state") {
+        val state = CheckpointState(
+          runId = "run-789",
+          pipelineName = "daily-batch",
+          startedAt = testInstant,
+          completedComponents = List.empty,
+          lastCheckpointedIndex = 4,
+          totalComponents = 5,
+          status = CheckpointStatus.Completed
+        )
+
+        val json     = CheckpointSerializer.toJson(state)
+        val restored = CheckpointSerializer.fromJson(json)
+
+        restored shouldBe state
+      }
+
+      it("should handle completed components") {
+        val components = List(
+          ComponentCheckpoint(
+            index = 0,
+            name = "Component1",
+            instanceType = "com.example.Component1",
+            startedAt = testInstant,
+            completedAt = testInstant.plusMillis(100),
+            durationMs = 100L
+          ),
+          ComponentCheckpoint(
+            index = 1,
+            name = "Component2",
+            instanceType = "com.example.Component2",
+            startedAt = testInstant.plusMillis(100),
+            completedAt = testInstant.plusMillis(250),
+            durationMs = 150L
+          )
+        )
+
+        val state = CheckpointState(
+          runId = "run-abc",
+          pipelineName = "multi-step",
+          startedAt = testInstant,
+          completedComponents = components,
+          lastCheckpointedIndex = 1,
+          totalComponents = 5,
+          status = CheckpointStatus.Running
+        )
+
+        val json     = CheckpointSerializer.toJson(state)
+        val restored = CheckpointSerializer.fromJson(json)
+
+        restored shouldBe state
+        (restored.completedComponents should have).length(2)
+        restored.completedComponents.head.name shouldBe "Component1"
+        restored.completedComponents(1).durationMs shouldBe 150L
+      }
+
+      it("should handle resumedFrom field") {
+        val state = CheckpointState(
+          runId = "run-resumed",
+          pipelineName = "resumable-pipeline",
+          startedAt = testInstant,
+          completedComponents = List.empty,
+          lastCheckpointedIndex = 2,
+          totalComponents = 5,
+          status = CheckpointStatus.Running,
+          resumedFrom = Some("run-original")
+        )
+
+        val json     = CheckpointSerializer.toJson(state)
+        val restored = CheckpointSerializer.fromJson(json)
+
+        restored shouldBe state
+        restored.resumedFrom shouldBe Some("run-original")
+      }
+
+      it("should handle empty resumedFrom") {
+        val state = CheckpointState(
+          runId = "run-fresh",
+          pipelineName = "fresh-pipeline",
+          startedAt = testInstant,
+          completedComponents = List.empty,
+          lastCheckpointedIndex = -1,
+          totalComponents = 3,
+          status = CheckpointStatus.Running,
+          resumedFrom = None
+        )
+
+        val json     = CheckpointSerializer.toJson(state)
+        val restored = CheckpointSerializer.fromJson(json)
+
+        restored.resumedFrom shouldBe None
+      }
+    }
+
+    describe("special character handling") {
+
+      it("should escape quotes in pipeline name") {
+        val state = CheckpointState(
+          runId = "run-123",
+          pipelineName = """Pipeline with "quotes"""",
+          startedAt = testInstant,
+          completedComponents = List.empty,
+          lastCheckpointedIndex = -1,
+          totalComponents = 1,
+          status = CheckpointStatus.Running
+        )
+
+        val json     = CheckpointSerializer.toJson(state)
+        val restored = CheckpointSerializer.fromJson(json)
+
+        restored.pipelineName shouldBe """Pipeline with "quotes""""
+      }
+
+      it("should escape newlines in error message") {
+        val state = CheckpointState(
+          runId = "run-123",
+          pipelineName = "test",
+          startedAt = testInstant,
+          completedComponents = List.empty,
+          lastCheckpointedIndex = 1,
+          totalComponents = 3,
+          status = CheckpointStatus.Failed("Error:\nLine 2\nLine 3", 2)
+        )
+
+        val json     = CheckpointSerializer.toJson(state)
+        val restored = CheckpointSerializer.fromJson(json)
+
+        restored.status match {
+          case CheckpointStatus.Failed(msg, _) =>
+            msg should include("\n")
+          case _ =>
+            fail("Expected Failed status")
+        }
+      }
+
+      it("should handle backslashes") {
+        val state = CheckpointState(
+          runId = "run-123",
+          pipelineName = "path\\to\\pipeline",
+          startedAt = testInstant,
+          completedComponents = List.empty,
+          lastCheckpointedIndex = -1,
+          totalComponents = 1,
+          status = CheckpointStatus.Running
+        )
+
+        val json     = CheckpointSerializer.toJson(state)
+        val restored = CheckpointSerializer.fromJson(json)
+
+        restored.pipelineName shouldBe "path\\to\\pipeline"
+      }
+    }
+
+    describe("error handling") {
+
+      it("should throw CheckpointException for invalid JSON") {
+        val invalidJson = "{ invalid json }"
+
+        a[CheckpointException] should be thrownBy {
+          CheckpointSerializer.fromJson(invalidJson)
+        }
+      }
+
+      it("should throw CheckpointException for missing fields") {
+        val incompleteJson = """{"runId":"123"}"""
+
+        a[CheckpointException] should be thrownBy {
+          CheckpointSerializer.fromJson(incompleteJson)
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointStateSpec.scala
+++ b/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/CheckpointStateSpec.scala
@@ -1,0 +1,155 @@
+package io.github.dwsmith1983.spark.pipeline.checkpoint
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.Instant
+
+/** Tests for CheckpointState and related models. */
+class CheckpointStateSpec extends AnyFunSpec with Matchers {
+
+  val testInstant: Instant = Instant.parse("2024-01-15T10:30:00Z")
+
+  describe("CheckpointState") {
+
+    it("should calculate resumeFromIndex as lastCheckpointedIndex + 1") {
+      val state = CheckpointState(
+        runId = "run-123",
+        pipelineName = "test-pipeline",
+        startedAt = testInstant,
+        completedComponents = List.empty,
+        lastCheckpointedIndex = 2,
+        totalComponents = 5,
+        status = CheckpointStatus.Running
+      )
+
+      state.resumeFromIndex shouldBe 3
+    }
+
+    it("should return 0 for resumeFromIndex when no components completed") {
+      val state = CheckpointState(
+        runId = "run-123",
+        pipelineName = "test-pipeline",
+        startedAt = testInstant,
+        completedComponents = List.empty,
+        lastCheckpointedIndex = -1,
+        totalComponents = 5,
+        status = CheckpointStatus.Running
+      )
+
+      state.resumeFromIndex shouldBe 0
+    }
+
+    describe("canResume") {
+
+      it("should return true for Failed status with incomplete work") {
+        val state = CheckpointState(
+          runId = "run-123",
+          pipelineName = "test-pipeline",
+          startedAt = testInstant,
+          completedComponents = List.empty,
+          lastCheckpointedIndex = 2,
+          totalComponents = 5,
+          status = CheckpointStatus.Failed("Error", 3)
+        )
+
+        state.canResume shouldBe true
+      }
+
+      it("should return false for Failed status when all components except last completed") {
+        val state = CheckpointState(
+          runId = "run-123",
+          pipelineName = "test-pipeline",
+          startedAt = testInstant,
+          completedComponents = List.empty,
+          lastCheckpointedIndex = 4,
+          totalComponents = 5,
+          status = CheckpointStatus.Failed("Error", 4)
+        )
+
+        // lastCheckpointedIndex (4) is not < totalComponents - 1 (4)
+        state.canResume shouldBe false
+      }
+
+      it("should return false for Running status") {
+        val state = CheckpointState(
+          runId = "run-123",
+          pipelineName = "test-pipeline",
+          startedAt = testInstant,
+          completedComponents = List.empty,
+          lastCheckpointedIndex = 2,
+          totalComponents = 5,
+          status = CheckpointStatus.Running
+        )
+
+        state.canResume shouldBe false
+      }
+
+      it("should return false for Completed status") {
+        val state = CheckpointState(
+          runId = "run-123",
+          pipelineName = "test-pipeline",
+          startedAt = testInstant,
+          completedComponents = List.empty,
+          lastCheckpointedIndex = 4,
+          totalComponents = 5,
+          status = CheckpointStatus.Completed
+        )
+
+        state.canResume shouldBe false
+      }
+    }
+
+    it("should track resumedFrom lineage") {
+      val state = CheckpointState(
+        runId = "run-456",
+        pipelineName = "test-pipeline",
+        startedAt = testInstant,
+        completedComponents = List.empty,
+        lastCheckpointedIndex = 2,
+        totalComponents = 5,
+        status = CheckpointStatus.Running,
+        resumedFrom = Some("run-123")
+      )
+
+      state.resumedFrom shouldBe Some("run-123")
+    }
+  }
+
+  describe("ComponentCheckpoint") {
+
+    it("should store component execution details") {
+      val checkpoint = ComponentCheckpoint(
+        index = 0,
+        name = "MyComponent",
+        instanceType = "com.example.MyComponent",
+        startedAt = testInstant,
+        completedAt = testInstant.plusMillis(100),
+        durationMs = 100L
+      )
+
+      checkpoint.index shouldBe 0
+      checkpoint.name shouldBe "MyComponent"
+      checkpoint.instanceType shouldBe "com.example.MyComponent"
+      checkpoint.durationMs shouldBe 100L
+    }
+  }
+
+  describe("CheckpointStatus") {
+
+    it("should have Running status") {
+      CheckpointStatus.Running shouldBe a[CheckpointStatus]
+    }
+
+    it("should have Completed status") {
+      CheckpointStatus.Completed shouldBe a[CheckpointStatus]
+    }
+
+    it("should have Failed status with details") {
+      val failed = CheckpointStatus.Failed("Connection timeout", 2)
+
+      failed.errorMessage shouldBe "Connection timeout"
+      failed.failedIndex shouldBe 2
+    }
+  }
+}

--- a/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/FileSystemCheckpointStoreSpec.scala
+++ b/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/checkpoint/FileSystemCheckpointStoreSpec.scala
@@ -1,0 +1,289 @@
+package io.github.dwsmith1983.spark.pipeline.checkpoint
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
+
+import java.nio.file.{Files, Path}
+import java.time.Instant
+
+/** Tests for FileSystemCheckpointStore. */
+class FileSystemCheckpointStoreSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach {
+
+  var tempDir: Path                    = _
+  var store: FileSystemCheckpointStore = _
+  val testInstant: Instant             = Instant.parse("2024-01-15T10:30:00Z")
+
+  override def beforeEach(): Unit = {
+    tempDir = Files.createTempDirectory("checkpoint-test")
+    store = FileSystemCheckpointStore(tempDir.toString)
+  }
+
+  override def afterEach(): Unit =
+    // Clean up temp directory
+    if (Files.exists(tempDir)) {
+      deleteRecursively(tempDir)
+    }
+
+  private def deleteRecursively(path: Path): Unit = {
+    if (Files.isDirectory(path)) {
+      val stream = Files.list(path)
+      try {
+        stream.forEach(child => deleteRecursively(child))
+      } finally {
+        stream.close()
+      }
+    }
+    Files.deleteIfExists(path)
+  }
+
+  def createTestState(
+    runId: String = "run-123",
+    pipelineName: String = "test-pipeline",
+    lastIndex: Int = -1,
+    status: CheckpointStatus = CheckpointStatus.Running
+  ): CheckpointState =
+    CheckpointState(
+      runId = runId,
+      pipelineName = pipelineName,
+      startedAt = testInstant,
+      completedComponents = List.empty,
+      lastCheckpointedIndex = lastIndex,
+      totalComponents = 5,
+      status = status
+    )
+
+  describe("FileSystemCheckpointStore") {
+
+    describe("save and load") {
+
+      it("should save and load checkpoint by runId") {
+        val state = createTestState()
+
+        store.save(state)
+        val loaded = store.loadByRunId("run-123")
+
+        loaded shouldBe defined
+        loaded.get shouldBe state
+      }
+
+      it("should overwrite existing checkpoint with same runId") {
+        val state1 = createTestState(lastIndex = 0)
+        val state2 = createTestState(lastIndex = 2)
+
+        store.save(state1)
+        store.save(state2)
+
+        val loaded = store.loadByRunId("run-123")
+        loaded.get.lastCheckpointedIndex shouldBe 2
+      }
+
+      it("should return None for non-existent runId") {
+        val loaded = store.loadByRunId("non-existent")
+        loaded shouldBe None
+      }
+
+      it("should store checkpoints in pipeline-specific directories") {
+        val state = createTestState()
+        store.save(state)
+
+        val pipelineDir = tempDir.resolve("test-pipeline")
+        Files.exists(pipelineDir) shouldBe true
+        Files.exists(pipelineDir.resolve("run-123.json")) shouldBe true
+      }
+    }
+
+    describe("loadLatest") {
+
+      it("should return the most recent failed checkpoint") {
+        val older = createTestState(
+          runId = "run-old",
+          status = CheckpointStatus.Failed("Error 1", 1)
+        ).copy(startedAt = testInstant.minusSeconds(100))
+
+        val newer = createTestState(
+          runId = "run-new",
+          status = CheckpointStatus.Failed("Error 2", 2)
+        ).copy(startedAt = testInstant)
+
+        store.save(older)
+        store.save(newer)
+
+        val latest = store.loadLatest("test-pipeline")
+        latest shouldBe defined
+        latest.get.runId shouldBe "run-new"
+      }
+
+      it("should only return Failed checkpoints") {
+        val running   = createTestState(runId = "run-1", status = CheckpointStatus.Running)
+        val completed = createTestState(runId = "run-2", status = CheckpointStatus.Completed)
+        val failed    = createTestState(runId = "run-3", status = CheckpointStatus.Failed("Error", 1))
+
+        store.save(running)
+        store.save(completed)
+        store.save(failed)
+
+        val latest = store.loadLatest("test-pipeline")
+        latest shouldBe defined
+        latest.get.runId shouldBe "run-3"
+      }
+
+      it("should return None when no failed checkpoints exist") {
+        val running = createTestState(status = CheckpointStatus.Running)
+        store.save(running)
+
+        val latest = store.loadLatest("test-pipeline")
+        latest shouldBe None
+      }
+
+      it("should return None for non-existent pipeline") {
+        val latest = store.loadLatest("non-existent-pipeline")
+        latest shouldBe None
+      }
+    }
+
+    describe("delete") {
+
+      it("should delete checkpoint by runId") {
+        val state = createTestState()
+        store.save(state)
+
+        store.loadByRunId("run-123") shouldBe defined
+
+        store.delete("run-123")
+
+        store.loadByRunId("run-123") shouldBe None
+      }
+
+      it("should not throw when deleting non-existent checkpoint") {
+        noException should be thrownBy {
+          store.delete("non-existent")
+        }
+      }
+    }
+
+    describe("listIncomplete") {
+
+      it("should list all incomplete checkpoints") {
+        val failed1 = createTestState(
+          runId = "run-1",
+          pipelineName = "pipeline-a",
+          status = CheckpointStatus.Failed("Error", 1)
+        )
+        val failed2 = createTestState(
+          runId = "run-2",
+          pipelineName = "pipeline-b",
+          status = CheckpointStatus.Failed("Error", 2)
+        )
+        val running = createTestState(
+          runId = "run-3",
+          pipelineName = "pipeline-a",
+          status = CheckpointStatus.Running
+        )
+
+        store.save(failed1)
+        store.save(failed2)
+        store.save(running)
+
+        val incomplete = store.listIncomplete()
+        (incomplete should have).length(2)
+        (incomplete.map(_.runId) should contain).allOf("run-1", "run-2")
+      }
+
+      it("should list incomplete checkpoints for specific pipeline") {
+        val failed1 = createTestState(
+          runId = "run-1",
+          pipelineName = "pipeline-a",
+          status = CheckpointStatus.Failed("Error", 1)
+        )
+        val failed2 = createTestState(
+          runId = "run-2",
+          pipelineName = "pipeline-b",
+          status = CheckpointStatus.Failed("Error", 2)
+        )
+
+        store.save(failed1)
+        store.save(failed2)
+
+        val incomplete = store.listIncomplete("pipeline-a")
+        (incomplete should have).length(1)
+        incomplete.head.runId shouldBe "run-1"
+      }
+
+      it("should return empty list when no incomplete checkpoints") {
+        val completed = createTestState(status = CheckpointStatus.Completed)
+        store.save(completed)
+
+        val incomplete = store.listIncomplete()
+        incomplete shouldBe empty
+      }
+    }
+
+    describe("pipeline name sanitization") {
+
+      it("should sanitize pipeline names with special characters") {
+        val state = createTestState(pipelineName = "My Pipeline (prod)/v2")
+        store.save(state)
+
+        val loaded = store.loadLatest("My Pipeline (prod)/v2")
+        loaded shouldBe None // Sanitized name won't match
+
+        // The file should exist with sanitized name
+        val sanitizedDir = tempDir.resolve("My_Pipeline__prod__v2")
+        Files.exists(sanitizedDir) shouldBe true
+      }
+
+      it("should handle spaces in pipeline names") {
+        val state = createTestState(pipelineName = "My Data Pipeline")
+        store.save(state)
+
+        val sanitizedDir = tempDir.resolve("My_Data_Pipeline")
+        Files.exists(sanitizedDir) shouldBe true
+      }
+    }
+
+    describe("atomic writes") {
+
+      it("should not leave temp files on successful save") {
+        val state = createTestState()
+        store.save(state)
+
+        val pipelineDir = tempDir.resolve("test-pipeline")
+        val stream      = Files.list(pipelineDir)
+        try {
+          stream.forEach(f => (f.getFileName.toString should not).startWith("."))
+        } finally {
+          stream.close()
+        }
+      }
+    }
+  }
+
+  describe("CheckpointStore.NoOp") {
+
+    it("should not persist anything") {
+      val noOp  = CheckpointStore.NoOp
+      val state = createTestState()
+
+      noOp.save(state)
+      noOp.loadByRunId("run-123") shouldBe None
+      noOp.loadLatest("test-pipeline") shouldBe None
+      noOp.listIncomplete() shouldBe empty
+    }
+  }
+
+  describe("CheckpointException") {
+
+    it("should create save failure exception") {
+      val ex = CheckpointException.saveFailure("run-123", new RuntimeException("IO Error"))
+      ex.getMessage should include("run-123")
+      ex.getCause shouldBe a[RuntimeException]
+    }
+
+    it("should create config mismatch exception") {
+      val ex = CheckpointException.configMismatch(5, 3)
+      ex.getMessage should include("5")
+      ex.getMessage should include("3")
+    }
+  }
+}

--- a/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/config/SchemaContractSpec.scala
+++ b/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/config/SchemaContractSpec.scala
@@ -6,9 +6,7 @@ import org.scalatest.matchers.should.Matchers
 import pureconfig._
 import pureconfig.generic.auto._
 
-/**
- * Tests for schema contract functionality.
- */
+/** Tests for schema contract functionality. */
 class SchemaContractSpec extends AnyFunSpec with Matchers {
 
   describe("SchemaField") {
@@ -287,12 +285,12 @@ class SchemaContractSpec extends AnyFunSpec with Matchers {
 
       it("should collect multiple errors") {
         val output = SchemaDefinition(Seq(
-          SchemaField("id", "integer")  // Wrong type
+          SchemaField("id", "integer") // Wrong type
         ))
         val input = SchemaDefinition(Seq(
           SchemaField("id", "string"),
-          SchemaField("name", "string"),  // Missing
-          SchemaField("age", "integer")   // Missing
+          SchemaField("name", "string"), // Missing
+          SchemaField("age", "integer")  // Missing
         ))
 
         val result = SchemaValidator.validate(output, input)

--- a/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/dq/DataQualityConfigSpec.scala
+++ b/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/dq/DataQualityConfigSpec.scala
@@ -68,9 +68,9 @@ class DataQualityConfigSpec extends AnyFunSpec with Matchers {
 
       it("should support exhaustive pattern matching") {
         def describe(timing: CheckTiming): String = timing match {
-          case CheckTiming.BeforePipeline          => "before"
-          case CheckTiming.AfterPipeline           => "after"
-          case CheckTiming.AfterComponent(name)    => s"after:$name"
+          case CheckTiming.BeforePipeline       => "before"
+          case CheckTiming.AfterPipeline        => "after"
+          case CheckTiming.AfterComponent(name) => s"after:$name"
         }
 
         describe(CheckTiming.BeforePipeline) shouldBe "before"

--- a/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/dq/DataQualitySinkSpec.scala
+++ b/core/src/test/scala/io/github/dwsmith1983/spark/pipeline/dq/DataQualitySinkSpec.scala
@@ -12,8 +12,8 @@ import scala.io.Source
 /** Tests for DataQualitySink and related classes. */
 class DataQualitySinkSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach {
 
-  var tempDir: File   = _
-  var tempFile: File  = _
+  var tempDir: File      = _
+  var tempFile: File     = _
   val timestamp: Instant = Instant.parse("2024-01-01T00:00:00Z")
 
   override def beforeEach(): Unit = {
@@ -101,7 +101,7 @@ class DataQualitySinkSpec extends AnyFunSpec with Matchers with BeforeAndAfterEa
     }
 
     it("should use writeAll for multiple results") {
-      val sink    = DataQualitySink.file(tempFile.getAbsolutePath)
+      val sink = DataQualitySink.file(tempFile.getAbsolutePath)
       val results = Seq(
         DataQualityResult.Passed("c1", "t1", Map.empty, timestamp),
         DataQualityResult.Passed("c2", "t2", Map.empty, timestamp)

--- a/runner/src/test/scala/io/github/dwsmith1983/spark/pipeline/runner/SchemaValidationIntegrationSpec.scala
+++ b/runner/src/test/scala/io/github/dwsmith1983/spark/pipeline/runner/SchemaValidationIntegrationSpec.scala
@@ -12,14 +12,12 @@ import pureconfig.generic.auto._
 
 import scala.collection.mutable
 
-/**
- * Integration tests for schema contract validation in SimplePipelineRunner.
- */
+/** Integration tests for schema contract validation in SimplePipelineRunner. */
 class SchemaValidationIntegrationSpec
   extends AnyFunSpec
-  with Matchers
-  with BeforeAndAfterEach
-  with BeforeAndAfterAll {
+    with Matchers
+    with BeforeAndAfterEach
+    with BeforeAndAfterAll {
 
   override def beforeEach(): Unit = {
     SparkSessionWrapper.stop()
@@ -61,7 +59,7 @@ class SchemaValidationIntegrationSpec
           SimplePipelineRunner.run(config)
         }
 
-        SchemaTestTracker.executed should contain allOf ("producer-1", "consumer-1")
+        (SchemaTestTracker.executed should contain).allOf("producer-1", "consumer-1")
       }
     }
 
@@ -98,7 +96,7 @@ class SchemaValidationIntegrationSpec
           SimplePipelineRunner.run(config)
         }
 
-        SchemaTestTracker.executed should contain allOf ("producer-2", "consumer-2")
+        (SchemaTestTracker.executed should contain).allOf("producer-2", "consumer-2")
       }
 
       it("should fail validation when schemas are incompatible") {
@@ -173,7 +171,7 @@ class SchemaValidationIntegrationSpec
           SimplePipelineRunner.run(config)
         }
 
-        SchemaTestTracker.executed should contain allOf ("producer-4", "no-schema-4")
+        (SchemaTestTracker.executed should contain).allOf("producer-4", "no-schema-4")
       }
     }
 
@@ -319,11 +317,13 @@ object SchemaTestTracker {
 case class SchemaProducerConfig(id: String)
 
 object SchemaProducerComponent extends ConfigurableInstance {
+
   override def createFromConfig(conf: Config): SchemaProducerComponent =
     new SchemaProducerComponent(ConfigSource.fromConfig(conf).loadOrThrow[SchemaProducerConfig])
 }
 
 class SchemaProducerComponent(conf: SchemaProducerConfig) extends DataFlow with SchemaContract {
+
   override def outputContract: Option[SchemaDefinition] = Some(
     SchemaDefinition(Seq(
       SchemaField("id", "long", nullable = false),
@@ -342,11 +342,13 @@ class SchemaProducerComponent(conf: SchemaProducerConfig) extends DataFlow with 
 case class SchemaConsumerConfig(id: String)
 
 object SchemaConsumerComponent extends ConfigurableInstance {
+
   override def createFromConfig(conf: Config): SchemaConsumerComponent =
     new SchemaConsumerComponent(ConfigSource.fromConfig(conf).loadOrThrow[SchemaConsumerConfig])
 }
 
 class SchemaConsumerComponent(conf: SchemaConsumerConfig) extends DataFlow with SchemaContract {
+
   override def inputContract: Option[SchemaDefinition] = Some(
     SchemaDefinition(Seq(
       SchemaField("id", "long"),
@@ -364,11 +366,13 @@ class SchemaConsumerComponent(conf: SchemaConsumerConfig) extends DataFlow with 
 case class CompatibleConsumerConfig(id: String)
 
 object CompatibleConsumerComponent extends ConfigurableInstance {
+
   override def createFromConfig(conf: Config): CompatibleConsumerComponent =
     new CompatibleConsumerComponent(ConfigSource.fromConfig(conf).loadOrThrow[CompatibleConsumerConfig])
 }
 
 class CompatibleConsumerComponent(conf: CompatibleConsumerConfig) extends DataFlow with SchemaContract {
+
   override def inputContract: Option[SchemaDefinition] = Some(
     SchemaDefinition(Seq(
       SchemaField("id", "long"),
@@ -386,16 +390,18 @@ class CompatibleConsumerComponent(conf: CompatibleConsumerConfig) extends DataFl
 case class IncompatibleConsumerConfig(id: String)
 
 object IncompatibleConsumerComponent extends ConfigurableInstance {
+
   override def createFromConfig(conf: Config): IncompatibleConsumerComponent =
     new IncompatibleConsumerComponent(ConfigSource.fromConfig(conf).loadOrThrow[IncompatibleConsumerConfig])
 }
 
 class IncompatibleConsumerComponent(conf: IncompatibleConsumerConfig) extends DataFlow with SchemaContract {
+
   override def inputContract: Option[SchemaDefinition] = Some(
     SchemaDefinition(Seq(
       SchemaField("id", "long"),
       SchemaField("name", "string"),
-      SchemaField("missing_field", "integer")  // This field is not in producer output
+      SchemaField("missing_field", "integer") // This field is not in producer output
     ))
   )
 
@@ -409,11 +415,13 @@ class IncompatibleConsumerComponent(conf: IncompatibleConsumerConfig) extends Da
 case class NoSchemaConfig(id: String)
 
 object NoSchemaComponent extends ConfigurableInstance {
+
   override def createFromConfig(conf: Config): NoSchemaComponent =
     new NoSchemaComponent(ConfigSource.fromConfig(conf).loadOrThrow[NoSchemaConfig])
 }
 
 class NoSchemaComponent(conf: NoSchemaConfig) extends DataFlow {
+
   override def run(): Unit = {
     logger.info(s"NoSchemaComponent running: ${conf.id}")
     SchemaTestTracker.executed += conf.id

--- a/runtime/src/main/scala/io/github/dwsmith1983/spark/pipeline/dq/DataQualityCheck.scala
+++ b/runtime/src/main/scala/io/github/dwsmith1983/spark/pipeline/dq/DataQualityCheck.scala
@@ -181,10 +181,12 @@ final case class NullCheck(
       "total_rows"       -> totalCount,
       "columns_checked"  -> columns.mkString(","),
       "max_null_percent" -> maxNullPercent
-    ) ++ nullCounts.map { case (col, count, _) =>
-      s"${col}_null_count" -> (count: Any)
-    }.toMap ++ nullCounts.map { case (col, _, pct) =>
-      s"${col}_null_percent" -> (f"$pct%.2f": Any)
+    ) ++ nullCounts.map {
+      case (col, count, _) =>
+        s"${col}_null_count" -> (count: Any)
+    }.toMap ++ nullCounts.map {
+      case (col, _, pct) =>
+        s"${col}_null_percent" -> (f"$pct%.2f": Any)
     }.toMap
 
     if (failures.nonEmpty) {
@@ -279,6 +281,7 @@ final case class UniqueCheck(
   extends DataQualityCheck {
 
   require(columns.nonEmpty, "columns must not be empty")
+
   require(
     maxDuplicatePercent >= 0.0 && maxDuplicatePercent <= 100.0,
     "maxDuplicatePercent must be between 0 and 100"
@@ -310,11 +313,11 @@ final case class UniqueCheck(
     val dupPercent  = (dupCount.toDouble / totalCount) * 100.0
 
     val details = Map[String, Any](
-      "total_rows"           -> totalCount,
-      "unique_rows"          -> uniqueCount,
-      "duplicate_rows"       -> dupCount,
-      "duplicate_percent"    -> f"$dupPercent%.2f",
-      "columns_checked"      -> columns.mkString(","),
+      "total_rows"            -> totalCount,
+      "unique_rows"           -> uniqueCount,
+      "duplicate_rows"        -> dupCount,
+      "duplicate_percent"     -> f"$dupPercent%.2f",
+      "columns_checked"       -> columns.mkString(","),
       "max_duplicate_percent" -> maxDuplicatePercent
     ) ++ sampleFraction.map("sample_fraction" -> _)
 
@@ -357,6 +360,7 @@ final case class RangeCheck(
   extends DataQualityCheck {
 
   require(min.isDefined || max.isDefined, "At least one of min or max must be specified")
+
   (min, max) match {
     case (Some(minVal), Some(maxVal)) =>
       require(maxVal >= minVal, "max must be >= min")
@@ -465,7 +469,7 @@ final case class CustomSqlCheck(
 
   override val name: String = checkName
 
-  override def run(spark: SparkSession): DataQualityResult = {
+  override def run(spark: SparkSession): DataQualityResult =
     try {
       val result = spark.sql(sql).head()
       val passed = expectation(result)
@@ -494,7 +498,6 @@ final case class CustomSqlCheck(
           Map("sql" -> sql, "error" -> e.getClass.getSimpleName)
         )
     }
-  }
 }
 
 /**

--- a/runtime/src/main/scala/io/github/dwsmith1983/spark/pipeline/dq/DataQualityHooks.scala
+++ b/runtime/src/main/scala/io/github/dwsmith1983/spark/pipeline/dq/DataQualityHooks.scala
@@ -78,7 +78,7 @@ class DataQualityHooks(
   val sink: DataQualitySink = DataQualitySink.logging())
   extends PipelineHooks {
 
-  private val logger: Logger                                = LogManager.getLogger(classOf[DataQualityHooks])
+  private val logger: Logger                                 = LogManager.getLogger(classOf[DataQualityHooks])
   private val results: mutable.ListBuffer[DataQualityResult] = mutable.ListBuffer()
   private val failedChecks: mutable.ListBuffer[DataQualityResult.Failed] = mutable.ListBuffer()
 
@@ -88,14 +88,10 @@ class DataQualityHooks(
    */
   def getResults: Seq[DataQualityResult] = results.toSeq
 
-  /**
-   * Gets all failed check results.
-   */
+  /** Gets all failed check results. */
   def getFailedResults: Seq[DataQualityResult.Failed] = failedChecks.toSeq
 
-  /**
-   * Returns true if all checks passed (no failures).
-   */
+  /** Returns true if all checks passed (no failures). */
   def allChecksPassed: Boolean = failedChecks.isEmpty
 
   override def beforePipeline(config: PipelineConfig): Unit = {

--- a/runtime/src/main/scala/io/github/dwsmith1983/spark/pipeline/runtime/SparkSchemaConverter.scala
+++ b/runtime/src/main/scala/io/github/dwsmith1983/spark/pipeline/runtime/SparkSchemaConverter.scala
@@ -198,7 +198,7 @@ object SparkSchemaConverter {
    * @return List of validation error messages (empty if valid)
    */
   def validateAgainst(expected: SchemaDefinition, actual: StructType): List[String] = {
-    val errors = scala.collection.mutable.ListBuffer.empty[String]
+    val errors       = scala.collection.mutable.ListBuffer.empty[String]
     val actualFields = actual.fields.map(f => f.name -> f).toMap
 
     expected.fields.foreach { expectedField =>

--- a/runtime/src/test/scala/io/github/dwsmith1983/spark/pipeline/dq/DataQualityCheckSpec.scala
+++ b/runtime/src/test/scala/io/github/dwsmith1983/spark/pipeline/dq/DataQualityCheckSpec.scala
@@ -35,13 +35,12 @@ class DataQualityCheckSpec
   override def afterAll(): Unit =
     SparkSessionWrapper.stop()
 
-  override def afterEach(): Unit = {
+  override def afterEach(): Unit =
     spark.catalog.listTables().collect().foreach { t =>
       if (t.isTemporary) {
         spark.catalog.dropTempView(t.name)
       }
     }
-  }
 
   // Helper to create DataFrames without spark.implicits
   private def createIntDf(name: String, data: Seq[Int]): Unit = {
@@ -142,13 +141,16 @@ class DataQualityCheckSpec
     }
 
     it("should fail when null percentage exceeds threshold") {
-      createNullableTwoColDf("nulls_table", Seq(
-        (Some("a"), 1),
-        (None, 2),
-        (Some("c"), 3),
-        (None, 4),
-        (Some("e"), 5)
-      ))
+      createNullableTwoColDf(
+        "nulls_table",
+        Seq(
+          (Some("a"), 1),
+          (None, 2),
+          (Some("c"), 3),
+          (None, 4),
+          (Some("e"), 5)
+        )
+      )
 
       val check  = NullCheck("nulls_table", Seq("name"), maxNullPercent = 10.0)
       val result = check.run(spark)
@@ -158,13 +160,16 @@ class DataQualityCheckSpec
     }
 
     it("should pass when null percentage within threshold") {
-      createNullableTwoColDf("some_nulls_table", Seq(
-        (Some("a"), 1),
-        (None, 2),
-        (Some("c"), 3),
-        (Some("d"), 4),
-        (Some("e"), 5)
-      ))
+      createNullableTwoColDf(
+        "some_nulls_table",
+        Seq(
+          (Some("a"), 1),
+          (None, 2),
+          (Some("c"), 3),
+          (Some("d"), 4),
+          (Some("e"), 5)
+        )
+      )
 
       val check  = NullCheck("some_nulls_table", Seq("name"), maxNullPercent = 25.0)
       val result = check.run(spark)

--- a/runtime/src/test/scala/io/github/dwsmith1983/spark/pipeline/dq/DataQualityHooksSpec.scala
+++ b/runtime/src/test/scala/io/github/dwsmith1983/spark/pipeline/dq/DataQualityHooksSpec.scala
@@ -37,13 +37,12 @@ class DataQualityHooksSpec
   override def afterAll(): Unit =
     SparkSessionWrapper.stop()
 
-  override def afterEach(): Unit = {
+  override def afterEach(): Unit =
     spark.catalog.listTables().collect().foreach { t =>
       if (t.isTemporary) {
         spark.catalog.dropTempView(t.name)
       }
     }
-  }
 
   // Helper to create test DataFrames
   private def createIntDf(name: String, data: Seq[Int]): Unit = {

--- a/runtime/src/test/scala/io/github/dwsmith1983/spark/pipeline/runtime/SparkSchemaConverterSpec.scala
+++ b/runtime/src/test/scala/io/github/dwsmith1983/spark/pipeline/runtime/SparkSchemaConverterSpec.scala
@@ -7,9 +7,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
 
-/**
- * Tests for SparkSchemaConverter.
- */
+/** Tests for SparkSchemaConverter. */
 class SparkSchemaConverterSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll {
 
   var spark: SparkSession = _
@@ -153,7 +151,7 @@ class SparkSchemaConverterSpec extends AnyFunSpec with Matchers with BeforeAndAf
     describe("toStructField") {
 
       it("should convert a nullable field") {
-        val field = SchemaField("name", "string", nullable = true)
+        val field       = SchemaField("name", "string", nullable = true)
         val structField = SparkSchemaConverter.toStructField(field)
 
         structField.name shouldBe "name"
@@ -162,7 +160,7 @@ class SparkSchemaConverterSpec extends AnyFunSpec with Matchers with BeforeAndAf
       }
 
       it("should convert a non-nullable field") {
-        val field = SchemaField("id", "integer", nullable = false)
+        val field       = SchemaField("id", "integer", nullable = false)
         val structField = SparkSchemaConverter.toStructField(field)
 
         structField.name shouldBe "id"
@@ -171,7 +169,7 @@ class SparkSchemaConverterSpec extends AnyFunSpec with Matchers with BeforeAndAf
       }
 
       it("should include metadata") {
-        val field = SchemaField("amount", "decimal", metadata = Map("precision" -> "10"))
+        val field       = SchemaField("amount", "decimal", metadata = Map("precision" -> "10"))
         val structField = SparkSchemaConverter.toStructField(field)
 
         structField.metadata.getString("precision") shouldBe "10"
@@ -216,7 +214,7 @@ class SparkSchemaConverterSpec extends AnyFunSpec with Matchers with BeforeAndAf
       }
 
       it("should handle empty schema") {
-        val schema = SchemaDefinition.empty
+        val schema     = SchemaDefinition.empty
         val structType = SparkSchemaConverter.toStructType(schema)
 
         structType.fields shouldBe empty
@@ -242,7 +240,7 @@ class SparkSchemaConverterSpec extends AnyFunSpec with Matchers with BeforeAndAf
 
       it("should include description if provided") {
         val structType = StructType(Seq(StructField("id", LongType)))
-        val schema = SparkSchemaConverter.fromStructType(structType, Some("User table"))
+        val schema     = SparkSchemaConverter.fromStructType(structType, Some("User table"))
 
         schema.description shouldBe Some("User table")
       }
@@ -384,8 +382,8 @@ class SparkSchemaConverterSpec extends AnyFunSpec with Matchers with BeforeAndAf
 
       it("should collect multiple errors") {
         val expected = SchemaDefinition(Seq(
-          SchemaField("id", "string"),  // Wrong type
-          SchemaField("missing", "long")  // Missing
+          SchemaField("id", "string"),   // Wrong type
+          SchemaField("missing", "long") // Missing
         ))
         val actual = StructType(Seq(
           StructField("id", LongType)
@@ -408,12 +406,13 @@ class SparkSchemaConverterSpec extends AnyFunSpec with Matchers with BeforeAndAf
         ))
 
         val structType = SparkSchemaConverter.toStructType(original)
-        val roundTrip = SparkSchemaConverter.fromStructType(structType)
+        val roundTrip  = SparkSchemaConverter.fromStructType(structType)
 
         roundTrip.fieldNames shouldBe original.fieldNames
-        roundTrip.fields.zip(original.fields).foreach { case (rt, orig) =>
-          rt.name shouldBe orig.name
-          rt.nullable shouldBe orig.nullable
+        roundTrip.fields.zip(original.fields).foreach {
+          case (rt, orig) =>
+            rt.name shouldBe orig.name
+            rt.nullable shouldBe orig.nullable
         }
       }
     }

--- a/website/docs/checkpointing.md
+++ b/website/docs/checkpointing.md
@@ -1,0 +1,273 @@
+# Checkpointing and Resume
+
+Spark Pipeline Framework supports checkpointing for fault tolerance, enabling pipelines to resume from the last successful component after a failure instead of restarting from the beginning.
+
+## Overview
+
+Checkpointing works by:
+1. Saving component completion state after each successful step
+2. Persisting checkpoint data to a configurable storage location
+3. Allowing failed pipelines to resume from the last checkpoint
+
+This is particularly useful for:
+- Long-running pipelines with expensive computations
+- Pipelines that may fail due to transient errors
+- Recovery from infrastructure issues
+
+## Quick Start
+
+Enable checkpointing in your pipeline configuration:
+
+```json
+pipeline {
+  pipeline-name = "My ETL Pipeline"
+
+  checkpoint {
+    enabled = true
+    location = "/tmp/spark-checkpoints"
+  }
+
+  pipeline-components = [
+    // ...
+  ]
+}
+```
+
+Run with checkpoint support:
+
+```scala
+import io.github.dwsmith1983.spark.pipeline.runner.SimplePipelineRunner
+
+// Runs with checkpointing enabled per config
+SimplePipelineRunner.runWithCheckpointing("/path/to/pipeline.conf")
+```
+
+## Configuration Options
+
+The `checkpoint` block supports the following options:
+
+```json
+pipeline {
+  checkpoint {
+    enabled = true                           // Enable checkpointing
+    location = "/data/checkpoints"           // Storage location
+    auto-resume = false                      // Auto-resume on startup
+    cleanup-on-success = true                // Delete checkpoint on success
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | Boolean | `false` | Whether checkpointing is active |
+| `location` | String | System temp | Directory for checkpoint storage |
+| `auto-resume` | Boolean | `false` | Automatically resume from last failed checkpoint |
+| `cleanup-on-success` | Boolean | `true` | Delete checkpoint files after successful run |
+
+### Storage Locations
+
+Checkpoint location can be:
+- **Local filesystem**: `/tmp/checkpoints` or `file:///tmp/checkpoints`
+- **HDFS**: `hdfs:///spark-checkpoints`
+- **S3**: `s3a://my-bucket/checkpoints`
+
+## Resuming Failed Pipelines
+
+### Manual Resume
+
+When a pipeline fails, you can resume it by specifying the run ID:
+
+```scala
+import io.github.dwsmith1983.spark.pipeline.runner.SimplePipelineRunner
+
+// Resume from a specific failed run
+SimplePipelineRunner.resume(
+  configPath = "/path/to/pipeline.conf",
+  runId = "abc123-def456"
+)
+```
+
+### Auto-Resume Mode
+
+With `auto-resume = true`, the pipeline automatically resumes from the last failed checkpoint:
+
+```json
+pipeline {
+  checkpoint {
+    enabled = true
+    location = "/data/checkpoints"
+    auto-resume = true
+  }
+}
+```
+
+```scala
+// Automatically resumes if a failed checkpoint exists
+SimplePipelineRunner.runWithCheckpointing("/path/to/pipeline.conf")
+```
+
+### Listing Resumable Checkpoints
+
+Find all failed checkpoints that can be resumed:
+
+```scala
+import io.github.dwsmith1983.spark.pipeline.checkpoint._
+import io.github.dwsmith1983.spark.pipeline.runner.SimplePipelineRunner
+
+val store = FileSystemCheckpointStore("/data/checkpoints")
+val checkpoints = SimplePipelineRunner.listResumableCheckpoints("My ETL Pipeline", store)
+
+checkpoints.foreach { cp =>
+  println(s"Run: ${cp.runId}")
+  println(s"  Failed at: component ${cp.lastCheckpointedIndex + 2}/${cp.totalComponents}")
+  println(s"  Started: ${cp.startedAt}")
+}
+```
+
+## Programmatic Usage
+
+### Using CheckpointHooks Directly
+
+You can use checkpoint hooks independently for more control:
+
+```scala
+import io.github.dwsmith1983.spark.pipeline.checkpoint._
+import io.github.dwsmith1983.spark.pipeline.config.PipelineHooks
+import io.github.dwsmith1983.spark.pipeline.runner.SimplePipelineRunner
+
+// Create checkpoint store and hooks
+val store = FileSystemCheckpointStore("/data/checkpoints")
+val checkpointHooks = CheckpointHooks(store)
+
+// Combine with other hooks
+val loggingHooks = LoggingHooks.structured()
+val combined = PipelineHooks.compose(checkpointHooks, loggingHooks)
+
+// Run with combined hooks
+SimplePipelineRunner.run(config, combined)
+```
+
+### Custom Checkpoint Store
+
+Implement `CheckpointStore` for custom storage backends:
+
+```scala
+import io.github.dwsmith1983.spark.pipeline.checkpoint._
+
+class RedisCheckpointStore(host: String) extends CheckpointStore {
+  override def save(state: CheckpointState): Unit = {
+    // Save to Redis
+  }
+
+  override def loadLatest(pipelineName: String): Option[CheckpointState] = {
+    // Load from Redis
+  }
+
+  // ... implement other methods
+}
+```
+
+## Checkpoint State
+
+Each checkpoint captures:
+
+| Field | Description |
+|-------|-------------|
+| `runId` | Unique identifier for the pipeline run |
+| `pipelineName` | Name from pipeline configuration |
+| `startedAt` | When the pipeline started |
+| `completedComponents` | List of successfully completed components |
+| `lastCheckpointedIndex` | Index of last successful component |
+| `totalComponents` | Total number of components |
+| `status` | Running, Failed, or Completed |
+| `resumedFrom` | Original runId if this is a resumed run |
+
+## Best Practices
+
+### 1. Use Persistent Storage for Production
+
+```json
+checkpoint {
+  enabled = true
+  location = "s3a://my-bucket/spark-checkpoints"
+}
+```
+
+### 2. Set Appropriate Cleanup Policy
+
+- Use `cleanup-on-success = true` for most cases to avoid checkpoint accumulation
+- Set `cleanup-on-success = false` if you need audit trails
+
+### 3. Handle Configuration Changes
+
+Checkpointing validates that the pipeline configuration matches before resuming. If you change the number of components, you cannot resume from an old checkpoint.
+
+### 4. Combine with Other Hooks
+
+```scala
+val hooks = PipelineHooks.compose(
+  CheckpointHooks(store),      // Checkpointing
+  AuditHooks.toFile(auditPath), // Audit trail
+  MetricsHooks(registry)        // Metrics
+)
+```
+
+## Limitations
+
+- **Sequential execution only**: Checkpointing works with the current sequential component model
+- **No sub-component checkpoints**: Checkpoints are at component granularity
+- **Config must match**: Cannot resume if pipeline configuration changed
+- **Metadata only**: Checkpoints don't store intermediate DataFrames
+
+## Example: Full Pipeline with Checkpointing
+
+```json
+spark {
+  app-name = "Daily ETL"
+  config {
+    "spark.sql.shuffle.partitions" = "200"
+  }
+}
+
+pipeline {
+  pipeline-name = "Daily ETL Pipeline"
+  fail-fast = true
+
+  checkpoint {
+    enabled = true
+    location = "s3a://data-lake/checkpoints"
+    auto-resume = true
+    cleanup-on-success = true
+  }
+
+  pipeline-components = [
+    {
+      instance-type = "com.example.Extract"
+      instance-name = "Extract(orders)"
+      instance-config { ... }
+    },
+    {
+      instance-type = "com.example.Transform"
+      instance-name = "Transform(clean)"
+      instance-config { ... }
+    },
+    {
+      instance-type = "com.example.Load"
+      instance-name = "Load(warehouse)"
+      instance-config { ... }
+    }
+  ]
+}
+```
+
+```scala
+// Run with auto-resume - if Transform failed yesterday,
+// today's run will skip Extract and continue from Transform
+SimplePipelineRunner.runWithCheckpointing("/conf/daily-etl.conf")
+```
+
+## Next Steps
+
+- [Configuration](./configuration) - Learn about HOCON configuration
+- [Lifecycle Hooks](./hooks) - Add monitoring and error handling
+- [Deployment](./deployment) - Deploy pipelines to production

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -8,6 +8,7 @@ const sidebars: SidebarsConfig = {
     'config-validation',
     'secrets-management',
     'schema-contracts',
+    'checkpointing',
     'components',
     'hooks',
     'data-quality',


### PR DESCRIPTION
## Description

Implement checkpoint system to save pipeline progress after each component and allow resuming from the last successful component on failure.

**Key features:**
- `CheckpointState` model for tracking pipeline execution state
- `CheckpointStore` trait with `FileSystemCheckpointStore` implementation
- `CheckpointHooks` implementing `PipelineHooks` for automatic checkpointing
- `CheckpointConfig` for HOCON-based configuration
- Resume methods in `SimplePipelineRunner` (`resume`, `resumeFromConfig`)
- Auto-resume mode via configuration
- Atomic file writes using temp file + rename for crash safety

**Design decisions:**
- Manual JSON serialization to avoid external dependencies
- Scala 2.12/2.13 compatible (no JavaConverters/CollectionConverters)
- Configurable cleanup on success for auditing flexibility

## Type of Change
- [x] `feat`: New feature

## Related Issues
<!-- No linked issues -->

## Checklist
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Tests added/updated for changes (87 new tests)
- [x] `sbt scalafmtCheckAll` passes
- [x] `sbt test` passes (428 tests all passing)
- [x] Documentation updated (website/docs/checkpointing.md)


Closes #50
