### PR TITLE
feat(core): add shared streaming configs for Delta Lake and Iceberg

### DIFF
--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/streaming/config/DeltaLakeConfig.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/streaming/config/DeltaLakeConfig.scala
@@ -1,0 +1,167 @@
+package io.github.dwsmith1983.spark.pipeline.streaming.config
+
+/**
+ * Configuration for Delta Lake streaming sources and sinks.
+ *
+ * This configuration is shared between [[io.github.dwsmith1983.spark.pipeline.streaming.sources.delta.DeltaStreamingSource]]
+ * and Delta streaming sinks. It supports both reading (with Change Data Feed)
+ * and writing (with merge, append, overwrite modes).
+ *
+ * == Source Configuration ==
+ *
+ * When using Delta Lake as a streaming source, you can read the table as a
+ * continuous stream of changes. Enable `readChangeDataFeed` to get CDC events.
+ *
+ * {{{
+ * val sourceConfig = DeltaLakeConfig(
+ *   path = "/data/events",
+ *   readChangeDataFeed = true,
+ *   startingVersion = Some(10L)
+ * )
+ * }}}
+ *
+ * == Sink Configuration ==
+ *
+ * When writing to Delta Lake, choose the appropriate write mode:
+ *
+ * {{{
+ * // Append mode (default)
+ * val appendConfig = DeltaLakeConfig(
+ *   path = "/data/events",
+ *   writeMode = DeltaWriteMode.Append
+ * )
+ *
+ * // Merge (upsert) mode
+ * val mergeConfig = DeltaLakeConfig(
+ *   path = "/data/events",
+ *   writeMode = DeltaWriteMode.Merge,
+ *   mergeCondition = Some("source.id = target.id")
+ * )
+ *
+ * // Overwrite with partition filter
+ * val overwriteConfig = DeltaLakeConfig(
+ *   path = "/data/events",
+ *   writeMode = DeltaWriteMode.Overwrite,
+ *   replaceWhere = Some("date >= '2024-01-01'")
+ * )
+ * }}}
+ *
+ * @param path                 Path to the Delta table (file path or cloud storage URI)
+ * @param readChangeDataFeed   Enable Change Data Feed for CDC events (source only)
+ * @param startingVersion      Start reading from this table version (source only)
+ * @param startingTimestamp    Start reading from this timestamp (source only, ISO-8601 format)
+ * @param ignoreChanges        Ignore file changes (re-reads) when streaming (source only)
+ * @param ignoreDeletes        Ignore file deletions when streaming (source only)
+ * @param maxFilesPerTrigger   Maximum files to process per micro-batch (source only)
+ * @param writeMode            Write mode: Append, Merge, or Overwrite (sink only)
+ * @param mergeCondition       SQL condition for merge operations (required when writeMode = Merge)
+ * @param mergeSchema          Automatically evolve schema on write (sink only)
+ * @param partitionBy          Columns to partition by when writing (sink only)
+ * @param replaceWhere         SQL predicate for conditional overwrites (sink only)
+ * @param schemaEvolutionMode  How to handle schema evolution
+ * @param options              Additional Delta Lake options passed to reader/writer
+ *
+ * @see [[https://docs.delta.io/latest/delta-streaming.html Delta Streaming Guide]]
+ * @see [[DeltaWriteMode]] for write mode options
+ * @see [[SchemaEvolutionMode]] for schema evolution options
+ */
+final case class DeltaLakeConfig(
+  path: String,
+  // Source-specific options
+  readChangeDataFeed: Boolean = false,
+  startingVersion: Option[Long] = None,
+  startingTimestamp: Option[String] = None,
+  ignoreChanges: Boolean = false,
+  ignoreDeletes: Boolean = false,
+  maxFilesPerTrigger: Int = 1000,
+  // Sink-specific options
+  writeMode: DeltaWriteMode = DeltaWriteMode.Append,
+  mergeCondition: Option[String] = None,
+  mergeSchema: Boolean = false,
+  partitionBy: List[String] = List.empty,
+  replaceWhere: Option[String] = None,
+  // Shared options
+  schemaEvolutionMode: SchemaEvolutionMode = SchemaEvolutionMode.AddColumns,
+  options: Map[String, String] = Map.empty) {
+
+  /**
+   * Validates the configuration for use as a streaming source.
+   *
+   * @throws IllegalArgumentException if startingVersion and startingTimestamp are both set
+   */
+  def validateForSource(): Unit =
+    require(
+      startingVersion.isEmpty || startingTimestamp.isEmpty,
+      "Cannot specify both startingVersion and startingTimestamp"
+    )
+
+  /**
+   * Validates the configuration for use as a streaming sink.
+   *
+   * @throws IllegalArgumentException if merge mode is used without mergeCondition
+   */
+  def validateForSink(): Unit =
+    writeMode match {
+      case DeltaWriteMode.Merge =>
+        require(
+          mergeCondition.isDefined,
+          "mergeCondition is required when writeMode is Merge"
+        )
+      case _ => // No additional validation needed
+    }
+}
+
+/** Companion object for [[DeltaLakeConfig]]. */
+object DeltaLakeConfig {
+
+  /**
+   * Creates a minimal source configuration for reading a Delta table.
+   *
+   * @param path Path to the Delta table
+   * @return A DeltaLakeConfig configured for streaming reads
+   */
+  def forSource(path: String): DeltaLakeConfig =
+    DeltaLakeConfig(path = path)
+
+  /**
+   * Creates a source configuration with Change Data Feed enabled.
+   *
+   * @param path            Path to the Delta table
+   * @param startingVersion Optional version to start reading from
+   * @return A DeltaLakeConfig configured for CDC streaming
+   */
+  def forCDC(path: String, startingVersion: Option[Long] = None): DeltaLakeConfig =
+    DeltaLakeConfig(
+      path = path,
+      readChangeDataFeed = true,
+      startingVersion = startingVersion
+    )
+
+  /**
+   * Creates a sink configuration for appending to a Delta table.
+   *
+   * @param path        Path to the Delta table
+   * @param partitionBy Optional partitioning columns
+   * @return A DeltaLakeConfig configured for append writes
+   */
+  def forAppend(path: String, partitionBy: List[String] = List.empty): DeltaLakeConfig =
+    DeltaLakeConfig(
+      path = path,
+      writeMode = DeltaWriteMode.Append,
+      partitionBy = partitionBy
+    )
+
+  /**
+   * Creates a sink configuration for merge (upsert) operations.
+   *
+   * @param path           Path to the Delta table
+   * @param mergeCondition SQL condition for matching rows (e.g., "source.id = target.id")
+   * @return A DeltaLakeConfig configured for merge writes
+   */
+  def forMerge(path: String, mergeCondition: String): DeltaLakeConfig =
+    DeltaLakeConfig(
+      path = path,
+      writeMode = DeltaWriteMode.Merge,
+      mergeCondition = Some(mergeCondition)
+    )
+}

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/streaming/config/DeltaWriteMode.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/streaming/config/DeltaWriteMode.scala
@@ -1,0 +1,49 @@
+package io.github.dwsmith1983.spark.pipeline.streaming.config
+
+/**
+ * Write modes for Delta Lake streaming sinks.
+ *
+ * Determines how data is written to Delta Lake tables. Each mode
+ * has different semantics and requirements.
+ *
+ * == Example ==
+ *
+ * {{{
+ * val config = DeltaLakeConfig(
+ *   path = "/data/events",
+ *   writeMode = DeltaWriteMode.Merge,
+ *   mergeCondition = Some("source.id = target.id")
+ * )
+ * }}}
+ *
+ * @see [[DeltaLakeConfig]] for full Delta Lake configuration options
+ */
+sealed trait DeltaWriteMode
+
+/** Companion object containing Delta write mode implementations. */
+object DeltaWriteMode {
+
+  /**
+   * Append new rows to the table.
+   *
+   * This is the default mode. New data is simply added to the table
+   * without affecting existing rows.
+   */
+  case object Append extends DeltaWriteMode
+
+  /**
+   * Merge (upsert) data into the table.
+   *
+   * Requires [[DeltaLakeConfig.mergeCondition]] to be set. Rows that
+   * match the condition are updated; non-matching rows are inserted.
+   */
+  case object Merge extends DeltaWriteMode
+
+  /**
+   * Overwrite data in the table.
+   *
+   * If [[DeltaLakeConfig.replaceWhere]] is set, only matching partitions
+   * are overwritten. Otherwise, the entire table is replaced.
+   */
+  case object Overwrite extends DeltaWriteMode
+}

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/streaming/config/IcebergConfig.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/streaming/config/IcebergConfig.scala
@@ -1,0 +1,175 @@
+package io.github.dwsmith1983.spark.pipeline.streaming.config
+
+/**
+ * Configuration for Apache Iceberg streaming sources and sinks.
+ *
+ * This configuration is shared between [[io.github.dwsmith1983.spark.pipeline.streaming.sources.iceberg.IcebergStreamingSource]]
+ * and Iceberg streaming sinks. It supports both incremental reads (streaming from
+ * snapshots) and various write modes (append, upsert, overwrite).
+ *
+ * == Source Configuration ==
+ *
+ * When using Iceberg as a streaming source, you can read incrementally from
+ * table snapshots. Optionally specify a starting timestamp to begin from.
+ *
+ * {{{
+ * val sourceConfig = IcebergConfig(
+ *   tablePath = "spark_catalog.db.events",
+ *   streamFromTimestamp = Some(1704067200000L)  // 2024-01-01 00:00:00 UTC
+ * )
+ * }}}
+ *
+ * == Sink Configuration ==
+ *
+ * When writing to Iceberg, choose the appropriate write mode:
+ *
+ * {{{
+ * // Append mode (default, most efficient)
+ * val appendConfig = IcebergConfig(
+ *   tablePath = "spark_catalog.db.events",
+ *   writeMode = IcebergWriteMode.Append
+ * )
+ *
+ * // Upsert mode (merge based on key columns)
+ * val upsertConfig = IcebergConfig(
+ *   tablePath = "spark_catalog.db.events",
+ *   writeMode = IcebergWriteMode.Upsert,
+ *   upsertKeys = List("event_id", "event_date")
+ * )
+ *
+ * // Dynamic partition overwrite
+ * val overwriteConfig = IcebergConfig(
+ *   tablePath = "spark_catalog.db.events",
+ *   writeMode = IcebergWriteMode.OverwriteDynamic
+ * )
+ * }}}
+ *
+ * == Table Path Format ==
+ *
+ * The table path can be specified in several formats:
+ *  - Catalog format: `catalog.database.table` (recommended)
+ *  - Path format: `/path/to/iceberg/table`
+ *  - Hadoop catalog: `hadoop_catalog.db.table`
+ *
+ * @param tablePath              Path to the Iceberg table (catalog.db.table or file path)
+ * @param catalogName            Name of the Iceberg catalog (default: spark_catalog)
+ * @param streamFromTimestamp    Start streaming from snapshots after this timestamp (epoch ms)
+ * @param skipDeleteSnapshots    Skip snapshots that only contain deletes (source only)
+ * @param skipOverwriteSnapshots Skip snapshots from overwrite operations (source only)
+ * @param writeMode              Write mode: Append, Upsert, or OverwriteDynamic (sink only)
+ * @param upsertKeys             Key columns for upsert operations (required when writeMode = Upsert)
+ * @param fanoutEnabled          Enable fanout writes for better parallelism (sink only)
+ * @param partitionBy            Columns to partition by when creating new tables (sink only)
+ * @param schemaEvolutionMode    How to handle schema evolution
+ * @param options                Additional Iceberg options passed to reader/writer
+ *
+ * @see [[https://iceberg.apache.org/docs/latest/spark-structured-streaming/ Iceberg Streaming Guide]]
+ * @see [[IcebergWriteMode]] for write mode options
+ * @see [[SchemaEvolutionMode]] for schema evolution options
+ */
+final case class IcebergConfig(
+  tablePath: String,
+  catalogName: String = "spark_catalog",
+  // Source-specific options
+  streamFromTimestamp: Option[Long] = None,
+  skipDeleteSnapshots: Boolean = false,
+  skipOverwriteSnapshots: Boolean = false,
+  // Sink-specific options
+  writeMode: IcebergWriteMode = IcebergWriteMode.Append,
+  upsertKeys: List[String] = List.empty,
+  fanoutEnabled: Boolean = false,
+  partitionBy: List[String] = List.empty,
+  // Shared options
+  schemaEvolutionMode: SchemaEvolutionMode = SchemaEvolutionMode.AddColumns,
+  options: Map[String, String] = Map.empty) {
+
+  /**
+   * Returns the fully qualified table identifier.
+   *
+   * If the tablePath already contains catalog information (has dots),
+   * it's returned as-is. Otherwise, the catalogName is prepended.
+   *
+   * @return The fully qualified table path
+   */
+  def fullTablePath: String =
+    if (tablePath.contains(".")) tablePath
+    else s"$catalogName.$tablePath"
+
+  /**
+   * Validates the configuration for use as a streaming source.
+   *
+   * Currently performs no additional validation beyond field types.
+   */
+  def validateForSource(): Unit = {
+    // No specific validation needed for source
+  }
+
+  /**
+   * Validates the configuration for use as a streaming sink.
+   *
+   * @throws IllegalArgumentException if upsert mode is used without upsertKeys
+   */
+  def validateForSink(): Unit =
+    writeMode match {
+      case IcebergWriteMode.Upsert =>
+        require(
+          upsertKeys.nonEmpty,
+          "upsertKeys must be non-empty when writeMode is Upsert"
+        )
+      case _ => // No additional validation needed
+    }
+}
+
+/** Companion object for [[IcebergConfig]]. */
+object IcebergConfig {
+
+  /**
+   * Creates a minimal source configuration for reading an Iceberg table.
+   *
+   * @param tablePath Path to the Iceberg table
+   * @return An IcebergConfig configured for streaming reads
+   */
+  def forSource(tablePath: String): IcebergConfig =
+    IcebergConfig(tablePath = tablePath)
+
+  /**
+   * Creates a source configuration starting from a specific timestamp.
+   *
+   * @param tablePath           Path to the Iceberg table
+   * @param streamFromTimestamp Epoch milliseconds to start streaming from
+   * @return An IcebergConfig configured for timestamp-based streaming
+   */
+  def forSourceFromTimestamp(tablePath: String, streamFromTimestamp: Long): IcebergConfig =
+    IcebergConfig(
+      tablePath = tablePath,
+      streamFromTimestamp = Some(streamFromTimestamp)
+    )
+
+  /**
+   * Creates a sink configuration for appending to an Iceberg table.
+   *
+   * @param tablePath   Path to the Iceberg table
+   * @param partitionBy Optional partitioning columns
+   * @return An IcebergConfig configured for append writes
+   */
+  def forAppend(tablePath: String, partitionBy: List[String] = List.empty): IcebergConfig =
+    IcebergConfig(
+      tablePath = tablePath,
+      writeMode = IcebergWriteMode.Append,
+      partitionBy = partitionBy
+    )
+
+  /**
+   * Creates a sink configuration for upsert operations.
+   *
+   * @param tablePath  Path to the Iceberg table
+   * @param upsertKeys Key columns for matching rows
+   * @return An IcebergConfig configured for upsert writes
+   */
+  def forUpsert(tablePath: String, upsertKeys: List[String]): IcebergConfig =
+    IcebergConfig(
+      tablePath = tablePath,
+      writeMode = IcebergWriteMode.Upsert,
+      upsertKeys = upsertKeys
+    )
+}

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/streaming/config/IcebergWriteMode.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/streaming/config/IcebergWriteMode.scala
@@ -1,0 +1,49 @@
+package io.github.dwsmith1983.spark.pipeline.streaming.config
+
+/**
+ * Write modes for Apache Iceberg streaming sinks.
+ *
+ * Determines how data is written to Iceberg tables. Each mode
+ * has different performance characteristics and use cases.
+ *
+ * == Example ==
+ *
+ * {{{
+ * val config = IcebergConfig(
+ *   tablePath = "catalog.db.events",
+ *   writeMode = IcebergWriteMode.Upsert,
+ *   upsertKeys = List("event_id")
+ * )
+ * }}}
+ *
+ * @see [[IcebergConfig]] for full Apache Iceberg configuration options
+ */
+sealed trait IcebergWriteMode
+
+/** Companion object containing Iceberg write mode implementations. */
+object IcebergWriteMode {
+
+  /**
+   * Append new rows to the table.
+   *
+   * This is the default and most efficient mode. New data is simply
+   * added to the table without affecting existing rows.
+   */
+  case object Append extends IcebergWriteMode
+
+  /**
+   * Upsert (merge) data into the table based on key columns.
+   *
+   * Requires [[IcebergConfig.upsertKeys]] to be set. Rows with matching
+   * keys are updated; rows with new keys are inserted.
+   */
+  case object Upsert extends IcebergWriteMode
+
+  /**
+   * Dynamically overwrite partitions based on the data being written.
+   *
+   * Only partitions that have data in the current batch are overwritten.
+   * Other partitions remain unchanged.
+   */
+  case object OverwriteDynamic extends IcebergWriteMode
+}

--- a/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/streaming/config/SchemaEvolutionMode.scala
+++ b/core/src/main/scala/io/github/dwsmith1983/spark/pipeline/streaming/config/SchemaEvolutionMode.scala
@@ -1,0 +1,51 @@
+package io.github.dwsmith1983.spark.pipeline.streaming.config
+
+/**
+ * Controls how schema evolution is handled for streaming sources and sinks.
+ *
+ * Schema evolution allows the schema of streaming data to change over time
+ * without breaking the pipeline. Different modes provide different levels
+ * of flexibility.
+ *
+ * == Example ==
+ *
+ * {{{
+ * val config = DeltaLakeConfig(
+ *   path = "/data/events",
+ *   schemaEvolutionMode = SchemaEvolutionMode.AddColumns
+ * )
+ * }}}
+ *
+ * @see [[DeltaLakeConfig]] for Delta Lake configuration
+ * @see [[IcebergConfig]] for Apache Iceberg configuration
+ */
+sealed trait SchemaEvolutionMode
+
+/** Companion object containing schema evolution mode implementations. */
+object SchemaEvolutionMode {
+
+  /**
+   * Reject any schema changes.
+   *
+   * Use this mode when schema stability is critical and any changes
+   * should cause the pipeline to fail.
+   */
+  case object None extends SchemaEvolutionMode
+
+  /**
+   * Allow adding new columns to the schema.
+   *
+   * This is a safe default that allows backward-compatible changes
+   * while rejecting potentially breaking changes like column removal
+   * or type changes.
+   */
+  case object AddColumns extends SchemaEvolutionMode
+
+  /**
+   * Allow all schema changes including column removal and type changes.
+   *
+   * Use with caution as this may lead to data quality issues if
+   * downstream consumers are not prepared for schema changes.
+   */
+  case object FullEvolution extends SchemaEvolutionMode
+}


### PR DESCRIPTION
## Description

Add shared configuration classes for Delta Lake and Apache Iceberg streaming that are used by both streaming sources and sinks.

**Files added:**
- `SchemaEvolutionMode.scala` - Sealed trait: None, AddColumns, FullEvolution
- `DeltaWriteMode.scala` - Sealed trait: Append, Merge, Overwrite
- `IcebergWriteMode.scala` - Sealed trait: Append, Upsert, OverwriteDynamic
- `DeltaLakeConfig.scala` - Combined source/sink config with CDC support
- `IcebergConfig.scala` - Combined source/sink config with upsert support

**Key features:**
- Clean ScalaDoc with usage examples
- Sealed traits for compile-time exhaustiveness checking
- Validation methods for source/sink specific constraints
- Factory methods for common use cases
- Generic `options: Map[String, String]` for flexibility

These configs enable parallel development: furiosa implements streaming sources while nux implements streaming sinks.

## Type of Change
- [x] `feat`: New feature

## Related Issues
Part of v1.3.0 Streaming Sources feature

## Checklist
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Tests added/updated for changes
- [x] `sbt scalafmtCheckAll` passes
- [x] `sbt test` passes (595 tests)
- [ ] Documentation updated (if applicable) - will be added with full feature