### PR TITLE
ci: remove workflow files from code change filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
               - '**/*.sbt'
               - 'project/**'
               - 'build.sbt'
-              - '.github/workflows/**'
 
   lint:
     name: Lint


### PR DESCRIPTION
## Description
Remove `.github/workflows/**` from the paths-filter code detection. Workflow-only changes should not trigger the full test suite since they don't affect Scala code behavior.

## Type of Change
- [x] `chore`: Maintenance (deps, CI, etc.)

## Related Issues
Part of v1.3.1 release preparation.

## Checklist
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/) format
- [x] Tests added/updated for changes (N/A - CI config only)
- [x] `sbt scalafmtCheckAll` passes (N/A - no Scala changes)
- [x] `sbt test` passes (N/A - no Scala changes)
- [x] Documentation updated (if applicable) (N/A)