### PR TITLE
fix: ScalaDoc @throws for Scala 2.12 compatibility

### DIFF
--- a/runtime/src/main/scala/io/github/dwsmith1983/spark/pipeline/streaming/sources/kafka/KafkaSourceConfig.scala
+++ b/runtime/src/main/scala/io/github/dwsmith1983/spark/pipeline/streaming/sources/kafka/KafkaSourceConfig.scala
@@ -93,7 +93,7 @@ final case class KafkaSourceConfig(
   /**
    * Validates the configuration.
    *
-   * @throws java.lang.IllegalArgumentException if configuration is invalid
+   * @note Throws `IllegalArgumentException` if configuration is invalid
    */
   def validate(): Unit = {
     require(bootstrapServers.nonEmpty, "bootstrapServers cannot be empty")


### PR DESCRIPTION
## Summary
- Changes `@throws java.lang.IllegalArgumentException` to `@note Throws \`IllegalArgumentException\``
- Scala 2.12 ScalaDoc cannot link to JDK classes, causing build failures
- This fixes the v1.3.1 publish failure

## Context
The v1.3.1 publish failed because ScalaDoc generation failed on Scala 2.12 with:
```
Could not find any member to link for "java.lang.IllegalArgumentException"
```

## Test plan
- [x] Verified ScalaDoc builds successfully with `sbt "runtimespark32_12/doc"`
- [ ] CI passes
- [ ] Merge and tag v1.3.2
- [ ] Publish to Maven Central